### PR TITLE
Added markdown files for openApi3 specifications

### DIFF
--- a/openapi3render/markdown_specs/charges.html.md
+++ b/openapi3render/markdown_specs/charges.html.md
@@ -1,0 +1,1160 @@
+---
+title: charges Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="charges-specification">charges Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="charges-specification-company-company_number-charges">company{company_number}charges</h2>
+
+## getChargeList
+
+<a id="opIdgetChargeList"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/charges \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/charges HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/charges',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/charges',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/charges', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/charges', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/charges");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/charges", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/charges`
+
+*Get a list of charges for a company*
+
+<h4 id="getchargelist-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number that the charge list is required for.|
+|items_per_page|query|integer|false|The number of charges to return per page.|
+|start_index|query|integer|false|The index into the entire result set that this result page starts.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "total_count": 0,
+  "unfiletered_count": 0,
+  "satisfied_count": 0,
+  "part_satisfied_count": 0,
+  "items": [
+    {
+      "etag": "string",
+      "id": "string",
+      "charge_code": "string",
+      "charge_number": 0,
+      "classification": [
+        {
+          "type": "charge-description",
+          "description": "string"
+        }
+      ],
+      "status": "outstanding",
+      "assets_ceased_released": "property-ceased-to-belong",
+      "acquired_on": "2020-04-08",
+      "delivered_on": "2020-04-08",
+      "resolved_on": "2020-04-08",
+      "covering_instrument_date": "2020-04-08",
+      "created_on": "2020-04-08",
+      "satisfied_on": "2020-04-08",
+      "particulars": [
+        {
+          "type": "short-particulars",
+          "description": "string",
+          "contains_floating_charge": true,
+          "contains_fixed_charge": true,
+          "floating_charge_covers_all": true,
+          "contains_negative_pledge": true,
+          "chargor_acting_as_bare_trustee": true
+        }
+      ],
+      "secured_details": [
+        {
+          "type": "amount-secured",
+          "description": "string"
+        }
+      ],
+      "scottish_alterations": [
+        {
+          "has_alterations_to_order": true,
+          "has_alterations_to_prohibitions": true,
+          "has_restricting_provisions": true
+        }
+      ],
+      "more_than_four_persons_entitled": true,
+      "persons_entitled": [
+        {
+          "name": "string"
+        }
+      ],
+      "transactions": [
+        {
+          "filing_type": "string",
+          "transaction_id": 0,
+          "delivered_on": "2020-04-08",
+          "insolvency_case_number": 0,
+          "links": [
+            {
+              "filing": "string",
+              "insolvency_case": "string"
+            }
+          ]
+        }
+      ],
+      "insolvency_cases": [
+        {
+          "case_number": 0,
+          "transaction_id": 0,
+          "links": [
+            {
+              "case": "string"
+            }
+          ]
+        }
+      ],
+      "links": [
+        {
+          "self": "string"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<h4 id="getchargelist-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[chargeList](#schemachargelist)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid request|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|None|
+
+<h4 id="getchargelist-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## getChargeDetails
+
+<a id="opIdgetChargeDetails"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/charges/{charge_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/charges/{charge_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/charges/{charge_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/charges/{charge_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/charges/{charge_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/charges/{charge_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/charges/{charge_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/charges/{charge_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/charges/{charge_id}`
+
+*Get a single charge for a company*
+
+<h4 id="getchargedetails-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number that the charge is required for.|
+|charge_id|path|string|true|The id of the charge details that are required.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "id": "string",
+  "charge_code": "string",
+  "charge_number": 0,
+  "classification": [
+    {
+      "type": "charge-description",
+      "description": "string"
+    }
+  ],
+  "status": "outstanding",
+  "assets_ceased_released": "property-ceased-to-belong",
+  "acquired_on": "2020-04-08",
+  "delivered_on": "2020-04-08",
+  "resolved_on": "2020-04-08",
+  "covering_instrument_date": "2020-04-08",
+  "created_on": "2020-04-08",
+  "satisfied_on": "2020-04-08",
+  "particulars": [
+    {
+      "type": "short-particulars",
+      "description": "string",
+      "contains_floating_charge": true,
+      "contains_fixed_charge": true,
+      "floating_charge_covers_all": true,
+      "contains_negative_pledge": true,
+      "chargor_acting_as_bare_trustee": true
+    }
+  ],
+  "secured_details": [
+    {
+      "type": "amount-secured",
+      "description": "string"
+    }
+  ],
+  "scottish_alterations": [
+    {
+      "has_alterations_to_order": true,
+      "has_alterations_to_prohibitions": true,
+      "has_restricting_provisions": true
+    }
+  ],
+  "more_than_four_persons_entitled": true,
+  "persons_entitled": [
+    {
+      "name": "string"
+    }
+  ],
+  "transactions": [
+    {
+      "filing_type": "string",
+      "transaction_id": 0,
+      "delivered_on": "2020-04-08",
+      "insolvency_case_number": 0,
+      "links": [
+        {
+          "filing": "string",
+          "insolvency_case": "string"
+        }
+      ]
+    }
+  ],
+  "insolvency_cases": [
+    {
+      "case_number": 0,
+      "transaction_id": 0,
+      "links": [
+        {
+          "case": "string"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "self": "string"
+    }
+  ]
+}
+```
+
+<h4 id="getchargedetails-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[chargeDetails](#schemachargedetails)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid request|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|None|
+
+<h4 id="getchargedetails-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_insolvency_cases">insolvency_cases</h3>
+<!-- backwards compatibility -->
+<a id="schemainsolvency_cases"></a>
+<a id="schema_insolvency_cases"></a>
+<a id="tocSinsolvency_cases"></a>
+<a id="tocsinsolvency_cases"></a>
+
+```json
+{
+  "case_number": 0,
+  "transaction_id": 0,
+  "links": [
+    {
+      "case": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|case_number|integer|false|none|The number of this insolvency case|
+|transaction_id|integer|false|none|The id of the insolvency filing|
+|links|[[insolvency_case_links](#schemainsolvency_case_links)]|false|none|The resources related to this insolvency case|
+
+<h3 id="tocS_transactions">transactions</h3>
+<!-- backwards compatibility -->
+<a id="schematransactions"></a>
+<a id="schema_transactions"></a>
+<a id="tocStransactions"></a>
+<a id="tocstransactions"></a>
+
+```json
+{
+  "filing_type": "string",
+  "transaction_id": 0,
+  "delivered_on": "2020-04-08",
+  "insolvency_case_number": 0,
+  "links": [
+    {
+      "filing": "string",
+      "insolvency_case": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|filing_type|string|false|none|Filing type which created, updated or satisfied the charge|
+|transaction_id|integer|false|none|The id of the filing|
+|delivered_on|string(date)|false|none|The date the filing was submitted to Companies House|
+|insolvency_case_number|integer|false|none|The insolvency case related to this filing|
+|links|[[transaction_links](#schematransaction_links)]|false|none|The resources related to this filing|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_chargeDetails">chargeDetails</h3>
+<!-- backwards compatibility -->
+<a id="schemachargedetails"></a>
+<a id="schema_chargeDetails"></a>
+<a id="tocSchargedetails"></a>
+<a id="tocschargedetails"></a>
+
+```json
+{
+  "etag": "string",
+  "id": "string",
+  "charge_code": "string",
+  "charge_number": 0,
+  "classification": [
+    {
+      "type": "charge-description",
+      "description": "string"
+    }
+  ],
+  "status": "outstanding",
+  "assets_ceased_released": "property-ceased-to-belong",
+  "acquired_on": "2020-04-08",
+  "delivered_on": "2020-04-08",
+  "resolved_on": "2020-04-08",
+  "covering_instrument_date": "2020-04-08",
+  "created_on": "2020-04-08",
+  "satisfied_on": "2020-04-08",
+  "particulars": [
+    {
+      "type": "short-particulars",
+      "description": "string",
+      "contains_floating_charge": true,
+      "contains_fixed_charge": true,
+      "floating_charge_covers_all": true,
+      "contains_negative_pledge": true,
+      "chargor_acting_as_bare_trustee": true
+    }
+  ],
+  "secured_details": [
+    {
+      "type": "amount-secured",
+      "description": "string"
+    }
+  ],
+  "scottish_alterations": [
+    {
+      "has_alterations_to_order": true,
+      "has_alterations_to_prohibitions": true,
+      "has_restricting_provisions": true
+    }
+  ],
+  "more_than_four_persons_entitled": true,
+  "persons_entitled": [
+    {
+      "name": "string"
+    }
+  ],
+  "transactions": [
+    {
+      "filing_type": "string",
+      "transaction_id": 0,
+      "delivered_on": "2020-04-08",
+      "insolvency_case_number": 0,
+      "links": [
+        {
+          "filing": "string",
+          "insolvency_case": "string"
+        }
+      ]
+    }
+  ],
+  "insolvency_cases": [
+    {
+      "case_number": 0,
+      "transaction_id": 0,
+      "links": [
+        {
+          "case": "string"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "self": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|none|
+|id|string|false|none|The id of the charge|
+|charge_code|string|false|none|The charge code is a replacement of the mortgage description|
+|charge_number|integer|true|none|The charge number is used to reference an individual charge|
+|classification|[[classificationDesc](#schemaclassificationdesc)]|true|none|Classification information|
+|status|string|true|none|The status of the charge.  For enumeration descriptions see `status` section in the enumeration mappings.|
+|assets_ceased_released|string|false|none|Cease/release information about the charge.  For enumeration descriptions see `assets-ceased-released` section in the enumeration mappings.|
+|acquired_on|string(date)|false|none|The date the property or undertaking was acquired on|
+|delivered_on|string(date)|false|none|The date the charge was submitted to Companies House|
+|resolved_on|string(date)|false|none|The date the issue was resolved on|
+|covering_instrument_date|string(date)|false|none|The date by which the series of debentures were created|
+|created_on|string(date)|false|none|The date the charge was created|
+|satisfied_on|string(date)|false|none|The date the charge was satisfied|
+|particulars|[[particularDesc](#schemaparticulardesc)]|false|none|Details of charge or undertaking|
+|secured_details|[[securedDetailsDesc](#schemasecureddetailsdesc)]|false|none|Information about what is secured against this charge|
+|scottish_alterations|[[alterationsDesc](#schemaalterationsdesc)]|false|none|Information about alterations for Scottish companies|
+|more_than_four_persons_entitled|boolean|false|none|Charge has more than four person entitled|
+|persons_entitled|[[persons_entitled](#schemapersons_entitled)]|false|none|People that are entitled to the charge|
+|transactions|[[transactions](#schematransactions)]|false|none|Transactions that have been filed for the charge.|
+|insolvency_cases|[[insolvency_cases](#schemainsolvency_cases)]|false|none|The insolvency cases related to this charge|
+|links|[[charge_links](#schemacharge_links)]|false|none|The resources related to this charge|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|status|outstanding|
+|status|fully-satisfied|
+|status|part-satisfied|
+|status|satisfied|
+|assets_ceased_released|property-ceased-to-belong|
+|assets_ceased_released|part-property-release-and-ceased-to-belong|
+|assets_ceased_released|part-property-released|
+|assets_ceased_released|part-property-ceased-to-belong|
+|assets_ceased_released|whole-property-released|
+|assets_ceased_released|multiple-filings|
+|assets_ceased_released|whole-property-released-and-ceased-to-belong|
+
+<h3 id="tocS_chargeList">chargeList</h3>
+<!-- backwards compatibility -->
+<a id="schemachargelist"></a>
+<a id="schema_chargeList"></a>
+<a id="tocSchargelist"></a>
+<a id="tocschargelist"></a>
+
+```json
+{
+  "etag": "string",
+  "total_count": 0,
+  "unfiletered_count": 0,
+  "satisfied_count": 0,
+  "part_satisfied_count": 0,
+  "items": [
+    {
+      "etag": "string",
+      "id": "string",
+      "charge_code": "string",
+      "charge_number": 0,
+      "classification": [
+        {
+          "type": "charge-description",
+          "description": "string"
+        }
+      ],
+      "status": "outstanding",
+      "assets_ceased_released": "property-ceased-to-belong",
+      "acquired_on": "2020-04-08",
+      "delivered_on": "2020-04-08",
+      "resolved_on": "2020-04-08",
+      "covering_instrument_date": "2020-04-08",
+      "created_on": "2020-04-08",
+      "satisfied_on": "2020-04-08",
+      "particulars": [
+        {
+          "type": "short-particulars",
+          "description": "string",
+          "contains_floating_charge": true,
+          "contains_fixed_charge": true,
+          "floating_charge_covers_all": true,
+          "contains_negative_pledge": true,
+          "chargor_acting_as_bare_trustee": true
+        }
+      ],
+      "secured_details": [
+        {
+          "type": "amount-secured",
+          "description": "string"
+        }
+      ],
+      "scottish_alterations": [
+        {
+          "has_alterations_to_order": true,
+          "has_alterations_to_prohibitions": true,
+          "has_restricting_provisions": true
+        }
+      ],
+      "more_than_four_persons_entitled": true,
+      "persons_entitled": [
+        {
+          "name": "string"
+        }
+      ],
+      "transactions": [
+        {
+          "filing_type": "string",
+          "transaction_id": 0,
+          "delivered_on": "2020-04-08",
+          "insolvency_case_number": 0,
+          "links": [
+            {
+              "filing": "string",
+              "insolvency_case": "string"
+            }
+          ]
+        }
+      ],
+      "insolvency_cases": [
+        {
+          "case_number": 0,
+          "transaction_id": 0,
+          "links": [
+            {
+              "case": "string"
+            }
+          ]
+        }
+      ],
+      "links": [
+        {
+          "self": "string"
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|total_count|integer|false|none|Total number of charges returned by the API ( filtering applies ).|
+|unfiletered_count|integer|false|none|Total number of charges ( filtering ignored ).|
+|satisfied_count|integer|false|none|Number of satisfied charges|
+|part_satisfied_count|integer|false|none|Number of part satisfied charges|
+|items|[[chargeDetails](#schemachargedetails)]|true|none|List of charges.|
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_persons_entitled">persons_entitled</h3>
+<!-- backwards compatibility -->
+<a id="schemapersons_entitled"></a>
+<a id="schema_persons_entitled"></a>
+<a id="tocSpersons_entitled"></a>
+<a id="tocspersons_entitled"></a>
+
+```json
+{
+  "name": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|The name of the person entitled.|
+
+<h3 id="tocS_alterationsDesc">alterationsDesc</h3>
+<!-- backwards compatibility -->
+<a id="schemaalterationsdesc"></a>
+<a id="schema_alterationsDesc"></a>
+<a id="tocSalterationsdesc"></a>
+<a id="tocsalterationsdesc"></a>
+
+```json
+{
+  "has_alterations_to_order": true,
+  "has_alterations_to_prohibitions": true,
+  "has_restricting_provisions": true
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|has_alterations_to_order|boolean|false|none|The charge has alterations to order|
+|has_alterations_to_prohibitions|boolean|false|none|The charge has alterations to prohibitions|
+|has_restricting_provisions|boolean|false|none|The charge has provisions restricting the creation of further charges|
+
+<h3 id="tocS_securedDetailsDesc">securedDetailsDesc</h3>
+<!-- backwards compatibility -->
+<a id="schemasecureddetailsdesc"></a>
+<a id="schema_securedDetailsDesc"></a>
+<a id="tocSsecureddetailsdesc"></a>
+<a id="tocssecureddetailsdesc"></a>
+
+```json
+{
+  "type": "amount-secured",
+  "description": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|The type of secured details.  For enumeration descriptions see `secured-details-description` section in the enumeration mappings.|
+|description|string|true|none|Details of the amount or obligation secured by the charge|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|amount-secured|
+|type|obligations-secured|
+
+<h3 id="tocS_classificationDesc">classificationDesc</h3>
+<!-- backwards compatibility -->
+<a id="schemaclassificationdesc"></a>
+<a id="schema_classificationDesc"></a>
+<a id="tocSclassificationdesc"></a>
+<a id="tocsclassificationdesc"></a>
+
+```json
+{
+  "type": "charge-description",
+  "description": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|The type of charge classication.  For enumeration descriptions see `classificationDesc` section in the enumeration mappings.|
+|description|string|true|none|Details of the charge classification|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|charge-description|
+|type|nature-of-charge|
+
+<h3 id="tocS_insolvency_case_links">insolvency_case_links</h3>
+<!-- backwards compatibility -->
+<a id="schemainsolvency_case_links"></a>
+<a id="schema_insolvency_case_links"></a>
+<a id="tocSinsolvency_case_links"></a>
+<a id="tocsinsolvency_case_links"></a>
+
+```json
+{
+  "case": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|case|string|false|none|Link to the insolvency case data|
+
+<h3 id="tocS_charge_links">charge_links</h3>
+<!-- backwards compatibility -->
+<a id="schemacharge_links"></a>
+<a id="schema_charge_links"></a>
+<a id="tocScharge_links"></a>
+<a id="tocscharge_links"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|Link to the this charge data|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_transaction_links">transaction_links</h3>
+<!-- backwards compatibility -->
+<a id="schematransaction_links"></a>
+<a id="schema_transaction_links"></a>
+<a id="tocStransaction_links"></a>
+<a id="tocstransaction_links"></a>
+
+```json
+{
+  "filing": "string",
+  "insolvency_case": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|filing|string|false|none|Link to the charge filing data|
+|insolvency_case|string|false|none|Link to the insolvency case related to this filing|
+
+<h3 id="tocS_particularDesc">particularDesc</h3>
+<!-- backwards compatibility -->
+<a id="schemaparticulardesc"></a>
+<a id="schema_particularDesc"></a>
+<a id="tocSparticulardesc"></a>
+<a id="tocsparticulardesc"></a>
+
+```json
+{
+  "type": "short-particulars",
+  "description": "string",
+  "contains_floating_charge": true,
+  "contains_fixed_charge": true,
+  "floating_charge_covers_all": true,
+  "contains_negative_pledge": true,
+  "chargor_acting_as_bare_trustee": true
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|The type of charge particulars.  For enumeration descriptions see `particular-description` section in the enumeration mappings.|
+|description|string|true|none|Details of charge particulars|
+|contains_floating_charge|boolean|false|none|The charge contains a floating charge|
+|contains_fixed_charge|boolean|false|none|The charge contains a fixed charge|
+|floating_charge_covers_all|boolean|false|none|The floating charge covers all the property or undertaking or the company|
+|contains_negative_pledge|boolean|false|none|The charge contains a negative pledge|
+|chargor_acting_as_bare_trustee|boolean|false|none|The chargor is acting as a bare trustee for the property|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|short-particulars|
+|type|charged-property-description|
+|type|charged-property-or-undertaking-description|
+|type|brief-description|
+

--- a/openapi3render/markdown_specs/companyAddress.html.md
+++ b/openapi3render/markdown_specs/companyAddress.html.md
@@ -1,0 +1,384 @@
+---
+title: companyAddress Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="companyaddress-specification">companyAddress Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="companyaddress-specification-company-company_number-registered-office-address">company{company_number}registered-office-address</h2>
+
+## readRegisteredOfficeAddress
+
+<a id="opIdreadRegisteredOfficeAddress"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/registered-office-address \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/registered-office-address HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/registered-office-address',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/registered-office-address',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/registered-office-address', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/registered-office-address', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/registered-office-address");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/registered-office-address", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/registered-office-address`
+
+*Get the current address of a company*
+
+<h4 id="readregisteredofficeaddress-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The number of the company to create an address for.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "premises": "string",
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "locality": "string",
+  "region": "string",
+  "postal_code": "string",
+  "country": "England",
+  "po_box": "string"
+}
+```
+
+<h4 id="readregisteredofficeaddress-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[registeredOfficeAddress](#schemaregisteredofficeaddress)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not found|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_serviceError">serviceError</h3>
+<!-- backwards compatibility -->
+<a id="schemaserviceerror"></a>
+<a id="schema_serviceError"></a>
+<a id="tocSserviceerror"></a>
+<a id="tocsserviceerror"></a>
+
+```json
+{
+  "error": "string",
+  "error_description": "string",
+  "exception_id": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|error|string|true|none|The error that occured.|
+|error_description|string|false|none|A description of the error.|
+|exception_id|string|false|none|A unique ID referencing the occurrence of the error.|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_registeredOfficeAddress">registeredOfficeAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisteredofficeaddress"></a>
+<a id="schema_registeredOfficeAddress"></a>
+<a id="tocSregisteredofficeaddress"></a>
+<a id="tocsregisteredofficeaddress"></a>
+
+```json
+{
+  "etag": "string",
+  "premises": "string",
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "locality": "string",
+  "region": "string",
+  "postal_code": "string",
+  "country": "England",
+  "po_box": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|premises|string|true|none|The property name or number.|
+|address_line_1|string|true|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|locality|string|true|none|The locality e.g London.|
+|region|string|false|none|The region e.g Surrey.|
+|postal_code|string|false|none|The postal code e.g CF14 3UZ.|
+|country|string|true|none|The country.|
+|po_box|string|false|none|The post-office box number.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|country|England|
+|country|Wales|
+|country|Scotland|
+|country|Northern Ireland|
+|country|Great Britain|
+|country|United Kingdom|
+|country|Not specified|
+

--- a/openapi3render/markdown_specs/companyOfficerList.html.md
+++ b/openapi3render/markdown_specs/companyOfficerList.html.md
@@ -1,0 +1,773 @@
+---
+title: companyOfficerList Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="companyofficerlist-specification">companyOfficerList Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="companyofficerlist-specification-company-company_number-officers">company{company_number}officers</h2>
+
+## officerList
+
+<a id="opIdofficerList"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/officers \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/officers HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/officers',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/officers',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/officers', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/officers', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/officers");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/officers", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/officers`
+
+*List the company officers*
+
+<h4 id="officerlist-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the officer list being requested.|
+|items_per_page|query|integer|false|The number of officers to return per page.|
+|register_type|query|string|false|The register_type determines which officer type is returned for the registers view. Accepted values are: <ul><li><code>directors</code></li><li><code>secretaries</code></li><li><code>llp-members</code></li></ul>The register_type field will only work if registers_view is set to true|
+|register_view|query|string|false|Display register specific information. If given register is held at Companies House, registers_view set to true and correct register_type specified, only active officers will be returned. Those will also have full date of birth. Accepted values are: <ul><li><code>true</code></li><li><code>false</code></li></ul>Defaults to false|
+|start_index|query|integer|false|The offset into the entire result set that this page starts.|
+|order_by|query|string|false|The field by which to order the result set. Possible values are: <ul><li><code>appointed_on</code></li><li><code>resigned_on</code></li><li><code>surname</code></li></ul>|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "active_count": 0,
+  "etag": "string",
+  "inactive_count": 0,
+  "items": [
+    {
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "appointed_on": "2020-04-08",
+      "country_of_residence": "string",
+      "date_of_birth": [
+        {
+          "day": 0,
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "links": [
+        {
+          "officer": [
+            {
+              "appointments": "string"
+            }
+          ]
+        }
+      ],
+      "name": "string",
+      "nationality": "string",
+      "occupation": "string",
+      "officer_role": "cic-manager",
+      "resigned_on": "2020-04-08",
+      "former_names": [
+        {
+          "forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "identification": [
+        {
+          "identification_type": "eea",
+          "legal_authority": "string",
+          "legal_form": "string",
+          "place_registered": "string",
+          "registration_number": "string"
+        }
+      ]
+    }
+  ],
+  "items_per_page": 0,
+  "kind": "officer-list",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "resigned_count": 0,
+  "start_index": 0,
+  "total_results": 0
+}
+```
+
+<h4 id="officerlist-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[officerList](#schemaofficerlist)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_formerNames">formerNames</h3>
+<!-- backwards compatibility -->
+<a id="schemaformernames"></a>
+<a id="schema_formerNames"></a>
+<a id="tocSformernames"></a>
+<a id="tocsformernames"></a>
+
+```json
+{
+  "forenames": "string",
+  "surname": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|forenames|string|false|none|Former forenames of the officer.|
+|surname|string|false|none|Former surnames of the officer.|
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_address">address</h3>
+<!-- backwards compatibility -->
+<a id="schemaaddress"></a>
+<a id="schema_address"></a>
+<a id="tocSaddress"></a>
+<a id="tocsaddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "care_of": "string",
+  "country": "string",
+  "locality": "string",
+  "po_box": "string",
+  "postal_code": "string",
+  "premises": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|false|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|care_of|string|false|none|The care of name.|
+|country|string|false|none|The country e.g. United Kingdom.|
+|locality|string|false|none|The locality e.g. London.|
+|po_box|string|false|none|The post-office box number.|
+|postal_code|string|false|none|The postal code e.g. CF14 3UZ.|
+|premises|string|false|none|The property name or number.|
+|region|string|false|none|The region e.g. Surrey.|
+
+<h3 id="tocS_itemLinkTypes">itemLinkTypes</h3>
+<!-- backwards compatibility -->
+<a id="schemaitemlinktypes"></a>
+<a id="schema_itemLinkTypes"></a>
+<a id="tocSitemlinktypes"></a>
+<a id="tocsitemlinktypes"></a>
+
+```json
+{
+  "officer": [
+    {
+      "appointments": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|officer|[[officerLinkTypes](#schemaofficerlinktypes)]|true|none|Links to other officer resources associated with this officer list item.|
+
+<h3 id="tocS_linkTypes">linkTypes</h3>
+<!-- backwards compatibility -->
+<a id="schemalinktypes"></a>
+<a id="schema_linkTypes"></a>
+<a id="tocSlinktypes"></a>
+<a id="tocslinktypes"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|Link to this officer list resource.|
+
+<h3 id="tocS_corporateIdent">corporateIdent</h3>
+<!-- backwards compatibility -->
+<a id="schemacorporateident"></a>
+<a id="schema_corporateIdent"></a>
+<a id="tocScorporateident"></a>
+<a id="tocscorporateident"></a>
+
+```json
+{
+  "identification_type": "eea",
+  "legal_authority": "string",
+  "legal_form": "string",
+  "place_registered": "string",
+  "registration_number": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|identification_type|string|false|none|none|
+|legal_authority|string|false|none|The legal authority supervising the company.|
+|legal_form|string|false|none|The legal form of the company as defined by its country of registration.|
+|place_registered|string|false|none|Place registered.|
+|registration_number|string|false|none|Company registration number.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|identification_type|eea|
+|identification_type|non-eea|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_dateOfBirth">dateOfBirth</h3>
+<!-- backwards compatibility -->
+<a id="schemadateofbirth"></a>
+<a id="schema_dateOfBirth"></a>
+<a id="tocSdateofbirth"></a>
+<a id="tocsdateofbirth"></a>
+
+```json
+{
+  "day": 0,
+  "month": 0,
+  "year": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|day|integer|false|none|The day of the date of birth.|
+|month|integer|true|none|The month of date of birth.|
+|year|integer|true|none|The year of date of birth.|
+
+<h3 id="tocS_officerLinkTypes">officerLinkTypes</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficerlinktypes"></a>
+<a id="schema_officerLinkTypes"></a>
+<a id="tocSofficerlinktypes"></a>
+<a id="tocsofficerlinktypes"></a>
+
+```json
+{
+  "appointments": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|appointments|string|true|none|Link to the officer appointment resource that this appointment is associated with.|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_officerList">officerList</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficerlist"></a>
+<a id="schema_officerList"></a>
+<a id="tocSofficerlist"></a>
+<a id="tocsofficerlist"></a>
+
+```json
+{
+  "active_count": 0,
+  "etag": "string",
+  "inactive_count": 0,
+  "items": [
+    {
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "appointed_on": "2020-04-08",
+      "country_of_residence": "string",
+      "date_of_birth": [
+        {
+          "day": 0,
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "links": [
+        {
+          "officer": [
+            {
+              "appointments": "string"
+            }
+          ]
+        }
+      ],
+      "name": "string",
+      "nationality": "string",
+      "occupation": "string",
+      "officer_role": "cic-manager",
+      "resigned_on": "2020-04-08",
+      "former_names": [
+        {
+          "forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "identification": [
+        {
+          "identification_type": "eea",
+          "legal_authority": "string",
+          "legal_form": "string",
+          "place_registered": "string",
+          "registration_number": "string"
+        }
+      ]
+    }
+  ],
+  "items_per_page": 0,
+  "kind": "officer-list",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "resigned_count": 0,
+  "start_index": 0,
+  "total_results": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|active_count|integer|true|none|The number of active officers in this result set.|
+|etag|string|true|none|The ETag of the resource.|
+|inactive_count|integer|true|none|The number of officers who have not resigned where the company status is dissolved or converted-closed in this result set.|
+|items|[[officerSummary](#schemaofficersummary)]|true|none|The list of officers.|
+|items_per_page|integer|true|none|The number of officers to return per page.|
+|kind|string|true|none|none|
+|links|[[linkTypes](#schemalinktypes)]|true|none|Links to other resources associated with this officer list resource.|
+|resigned_count|integer|true|none|The number of resigned officers in this result set.|
+|start_index|integer|true|none|The offset into the entire result set that this page starts.|
+|total_results|integer|false|none|The total number of officers in this result set.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|officer-list|
+
+<h3 id="tocS_officerSummary">officerSummary</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficersummary"></a>
+<a id="schema_officerSummary"></a>
+<a id="tocSofficersummary"></a>
+<a id="tocsofficersummary"></a>
+
+```json
+{
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "appointed_on": "2020-04-08",
+  "country_of_residence": "string",
+  "date_of_birth": [
+    {
+      "day": 0,
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "links": [
+    {
+      "officer": [
+        {
+          "appointments": "string"
+        }
+      ]
+    }
+  ],
+  "name": "string",
+  "nationality": "string",
+  "occupation": "string",
+  "officer_role": "cic-manager",
+  "resigned_on": "2020-04-08",
+  "former_names": [
+    {
+      "forenames": "string",
+      "surname": "string"
+    }
+  ],
+  "identification": [
+    {
+      "identification_type": "eea",
+      "legal_authority": "string",
+      "legal_form": "string",
+      "place_registered": "string",
+      "registration_number": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address|[[address](#schemaaddress)]|true|none|The correspondence address of the officer.|
+|appointed_on|string(date)|true|none|The date on which the officer was appointed.|
+|country_of_residence|string|false|none|The officer's country of residence.|
+|date_of_birth|[[dateOfBirth](#schemadateofbirth)]|false|none|Details of director date of birth.|
+|links|[[itemLinkTypes](#schemaitemlinktypes)]|true|none|Links to other resources associated with this officer list item.|
+|name|string|true|none|Corporate or natural officer name.|
+|nationality|string|false|none|The officer's nationality.|
+|occupation|string|false|none|The officer's job title.|
+|officer_role|string|true|none|none|
+|resigned_on|string(date)|false|none|The date on which the officer resigned.|
+|former_names|[[formerNames](#schemaformernames)]|false|none|Former names for the officer.|
+|identification|[[corporateIdent](#schemacorporateident)]|false|none|Only one from `eea` or `non-eea` can be supplied, not both.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|officer_role|cic-manager|
+|officer_role|corporate-director|
+|officer_role|corporate-llp-designated-member|
+|officer_role|corporate-llp-member|
+|officer_role|corporate-manager-of-an-eeig|
+|officer_role|corporate-member-of-a-management-organ|
+|officer_role|corporate-member-of-a-supervisory-organ|
+|officer_role|corporate-member-of-an-administrative-organ|
+|officer_role|corporate-nominee-director|
+|officer_role|corporate-nominee-secretary|
+|officer_role|corporate-secretary|
+|officer_role|director|
+|officer_role|general-partner-in-a-limited-partnership|
+|officer_role|judicial-factor|
+|officer_role|limited-partner-in-a-limited-partnership|
+|officer_role|llp-designated-member|
+|officer_role|llp-member|
+|officer_role|manager-of-an-eeig|
+|officer_role|member-of-a-management-organ|
+|officer_role|member-of-a-supervisory-organ|
+|officer_role|member-of-an-administrative-organ|
+|officer_role|nominee-director|
+|officer_role|nominee-secretary|
+|officer_role|person-authorised-to-accept|
+|officer_role|person-authorised-to-represent|
+|officer_role|person-authorised-to-represent-and-accept|
+|officer_role|receiver-and-manager|
+|officer_role|secretary|
+

--- a/openapi3render/markdown_specs/companyProfile.html.md
+++ b/openapi3render/markdown_specs/companyProfile.html.md
@@ -1,0 +1,1326 @@
+---
+title: companyProfile Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="companyprofile-specification">companyProfile Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="companyprofile-specification-company-company_number-">company{company_number}</h2>
+
+## readCompanyProfile
+
+<a id="opIdreadCompanyProfile"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}`
+
+*Get the basic company information*
+
+<h4 id="readcompanyprofile-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the basic information to return.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "accounts": [
+    {
+      "accounting_reference_date": [
+        {
+          "day": 0,
+          "month": 0
+        }
+      ],
+      "last_accounts": [
+        {
+          "made_up_to": "2020-04-08",
+          "period_start_on": "2020-04-08",
+          "period_end_on": "2020-04-08",
+          "type": "null"
+        }
+      ],
+      "next_accounts": [
+        {
+          "period_start_on": "2020-04-08",
+          "period_end_on": "2020-04-08",
+          "due_on": "2020-04-08",
+          "overdue": true
+        }
+      ],
+      "next_due": "2020-04-08",
+      "next_made_up_to": "2020-04-08",
+      "overdue": true
+    }
+  ],
+  "annual_return": [
+    {
+      "last_made_up_to": "2020-04-08",
+      "next_due": "2020-04-08",
+      "next_made_up_to": "2020-04-08",
+      "overdue": true
+    }
+  ],
+  "can_file": true,
+  "confirmation_statement": [
+    {
+      "last_made_up_to": "2020-04-08",
+      "next_due": "2020-04-08",
+      "next_made_up_to": "2020-04-08",
+      "overdue": true
+    }
+  ],
+  "company_name": "string",
+  "company_number": "string",
+  "date_of_creation": "2020-04-08",
+  "date_of_cessation": "2020-04-08",
+  "etag": "string",
+  "has_been_liquidated": true,
+  "has_charges": true,
+  "is_community_interest_company": true,
+  "subtype": "community-interest-company",
+  "jurisdiction": "england-wales",
+  "last_full_members_list_date": "2020-04-08",
+  "foreign_company_details": [
+    {
+      "originating_registry": [
+        {
+          "country": "string",
+          "name": "string"
+        }
+      ],
+      "registration_number": "string",
+      "governed_by": "string",
+      "company_type": "string",
+      "is_a_credit_finance_institution": true,
+      "accounts": [
+        {
+          "account_period_from": [
+            {
+              "day": 0,
+              "month": 0
+            }
+          ],
+          "account_period_to": [
+            {
+              "day": 0,
+              "month": 0
+            }
+          ],
+          "must_file_within": [
+            {
+              "months": 0
+            }
+          ]
+        }
+      ],
+      "business_activity": "string",
+      "accounting_requirement": "string"
+    }
+  ],
+  "registered_office_address": [
+    {
+      "care_of": "string",
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "country": "Wales",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "sic_codes": [
+    "string"
+  ],
+  "previous_company_names": [
+    {
+      "name": "string",
+      "effective_from": "2020-04-08",
+      "ceased_on": "2020-04-08"
+    }
+  ],
+  "company_status": "active",
+  "company_status_detail": "transferred-from-uk",
+  "type": "private-unlimited",
+  "external_registration_number": "string",
+  "has_insolvency_history": true,
+  "undeliverable_registered_office_address": true,
+  "registered_office_is_in_dispute": true,
+  "branch_company_details": [
+    {
+      "business_activity": "string",
+      "parent_company_number": "string",
+      "parent_company_name": "string"
+    }
+  ],
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control": "string",
+      "persons_with_significant_control_statements": "string",
+      "filing_history": "string",
+      "officers": "string",
+      "insolvency": "string",
+      "charges": "string",
+      "registers": "string"
+    }
+  ],
+  "partial_data_available": "full-data-available-from-financial-conduct-authority"
+}
+```
+
+<h4 id="readcompanyprofile-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[companyProfile](#schemacompanyprofile)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_foreignCompanyDetails">foreignCompanyDetails</h3>
+<!-- backwards compatibility -->
+<a id="schemaforeigncompanydetails"></a>
+<a id="schema_foreignCompanyDetails"></a>
+<a id="tocSforeigncompanydetails"></a>
+<a id="tocsforeigncompanydetails"></a>
+
+```json
+{
+  "originating_registry": [
+    {
+      "country": "string",
+      "name": "string"
+    }
+  ],
+  "registration_number": "string",
+  "governed_by": "string",
+  "company_type": "string",
+  "is_a_credit_finance_institution": true,
+  "accounts": [
+    {
+      "account_period_from": [
+        {
+          "day": 0,
+          "month": 0
+        }
+      ],
+      "account_period_to": [
+        {
+          "day": 0,
+          "month": 0
+        }
+      ],
+      "must_file_within": [
+        {
+          "months": 0
+        }
+      ]
+    }
+  ],
+  "business_activity": "string",
+  "accounting_requirement": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|originating_registry|[[originatingRegistry](#schemaoriginatingregistry)]|false|none|Company origin informations|
+|registration_number|string|false|none|Registration number in company of incorporation.|
+|governed_by|string|false|none|Law governing the company in country of incorporation.|
+|company_type|string|false|none|Legal form of the company in the country of incorporation.|
+|is_a_credit_finance_institution|boolean|false|none|Is it a financial or credit institution.|
+|accounts|[[accountInformation](#schemaaccountinformation)]|false|none|Foreign company account information.|
+|business_activity|string|false|none|Type of business undertaken by the company.|
+|accounting_requirement|string|false|none|Accounts requirement.|
+
+<h3 id="tocS_accountPeriodTo">accountPeriodTo</h3>
+<!-- backwards compatibility -->
+<a id="schemaaccountperiodto"></a>
+<a id="schema_accountPeriodTo"></a>
+<a id="tocSaccountperiodto"></a>
+<a id="tocsaccountperiodto"></a>
+
+```json
+{
+  "day": 0,
+  "month": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|day|integer|false|none|Day on which accounting period ends under parent law.|
+|month|integer|false|none|Month in which accounting period ends under parent law.|
+
+<h3 id="tocS_annualReturnInformation">annualReturnInformation</h3>
+<!-- backwards compatibility -->
+<a id="schemaannualreturninformation"></a>
+<a id="schema_annualReturnInformation"></a>
+<a id="tocSannualreturninformation"></a>
+<a id="tocsannualreturninformation"></a>
+
+```json
+{
+  "last_made_up_to": "2020-04-08",
+  "next_due": "2020-04-08",
+  "next_made_up_to": "2020-04-08",
+  "overdue": true
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|last_made_up_to|string(date)|false|none|The date the last annual return was made up to.|
+|next_due|string(date)|false|none|The date the next annual return is due. This member will only be returned if a confirmation statement has not been filed and the date is before 28th July 2016, otherwise refer to `confirmation_statement.next_due`|
+|next_made_up_to|string(date)|false|none|The date the next annual return should be made up to. This member will only be returned if a confirmation statement has not been filed and the date is before 30th July 2016, otherwise refer to `confirmation_statement.next_made_up_to`|
+|overdue|boolean|false|none|Flag indicating if the annual return is overdue.|
+
+<h3 id="tocS_linksType">linksType</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkstype"></a>
+<a id="schema_linksType"></a>
+<a id="tocSlinkstype"></a>
+<a id="tocslinkstype"></a>
+
+```json
+{
+  "self": "string",
+  "persons_with_significant_control": "string",
+  "persons_with_significant_control_statements": "string",
+  "filing_history": "string",
+  "officers": "string",
+  "insolvency": "string",
+  "charges": "string",
+  "registers": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of the resource.|
+|persons_with_significant_control|string|false|none|The URL of the company's persons with significant control list resource.|
+|persons_with_significant_control_statements|string|false|none|The URL of the company's persons with significant control statements list resource.|
+|filing_history|string|false|none|The URL of the company's filing history list resource.|
+|officers|string|false|none|The URL of the company's officer list resource.|
+|insolvency|string|false|none|The URL of the company's insolvency list resource|
+|charges|string|false|none|The URL of the company's charge resource|
+|registers|string|false|none|The URL of the registers resource for this company|
+
+<h3 id="tocS_previousCompanyNames">previousCompanyNames</h3>
+<!-- backwards compatibility -->
+<a id="schemapreviouscompanynames"></a>
+<a id="schema_previousCompanyNames"></a>
+<a id="tocSpreviouscompanynames"></a>
+<a id="tocspreviouscompanynames"></a>
+
+```json
+{
+  "name": "string",
+  "effective_from": "2020-04-08",
+  "ceased_on": "2020-04-08"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|The previous company name|
+|effective_from|string(date)|true|none|The date from which the company name was effective.|
+|ceased_on|string(date)|true|none|The date on which the company name ceased.|
+
+<h3 id="tocS_dateOfBirth">dateOfBirth</h3>
+<!-- backwards compatibility -->
+<a id="schemadateofbirth"></a>
+<a id="schema_dateOfBirth"></a>
+<a id="tocSdateofbirth"></a>
+<a id="tocsdateofbirth"></a>
+
+```json
+{
+  "day": 0,
+  "month": 0,
+  "year": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|day|integer|false|none|The day of the date of birth.|
+|month|integer|true|none|The month of date of birth.|
+|year|integer|true|none|The year of date of birth.|
+
+<h3 id="tocS_branchCompanyDetails">branchCompanyDetails</h3>
+<!-- backwards compatibility -->
+<a id="schemabranchcompanydetails"></a>
+<a id="schema_branchCompanyDetails"></a>
+<a id="tocSbranchcompanydetails"></a>
+<a id="tocsbranchcompanydetails"></a>
+
+```json
+{
+  "business_activity": "string",
+  "parent_company_number": "string",
+  "parent_company_name": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|business_activity|string|false|none|Type of business undertaken by the UK establishment.|
+|parent_company_number|string|false|none|Parent company number.|
+|parent_company_name|string|false|none|Parent company name.|
+
+<h3 id="tocS_accountsInformation">accountsInformation</h3>
+<!-- backwards compatibility -->
+<a id="schemaaccountsinformation"></a>
+<a id="schema_accountsInformation"></a>
+<a id="tocSaccountsinformation"></a>
+<a id="tocsaccountsinformation"></a>
+
+```json
+{
+  "accounting_reference_date": [
+    {
+      "day": 0,
+      "month": 0
+    }
+  ],
+  "last_accounts": [
+    {
+      "made_up_to": "2020-04-08",
+      "period_start_on": "2020-04-08",
+      "period_end_on": "2020-04-08",
+      "type": "null"
+    }
+  ],
+  "next_accounts": [
+    {
+      "period_start_on": "2020-04-08",
+      "period_end_on": "2020-04-08",
+      "due_on": "2020-04-08",
+      "overdue": true
+    }
+  ],
+  "next_due": "2020-04-08",
+  "next_made_up_to": "2020-04-08",
+  "overdue": true
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|accounting_reference_date|[[accountingReferenceDate](#schemaaccountingreferencedate)]|true|none|The Accounting Reference Date (ARD) of the company.|
+|last_accounts|[[lastAccounts](#schemalastaccounts)]|false|none|The last company accounts filed.|
+|next_accounts|[[nextAccounts](#schemanextaccounts)]|false|none|The next company accounts filed.|
+|next_due|string(date)|false|none|Deprecated. Please use next_accounts.due_on.|
+|next_made_up_to|string(date)|true|none|Deprecated. Please use next_accounts.period_end_on.|
+|overdue|boolean|true|none|Deprecated. Please use next_accounts.overdue|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_lastAccounts">lastAccounts</h3>
+<!-- backwards compatibility -->
+<a id="schemalastaccounts"></a>
+<a id="schema_lastAccounts"></a>
+<a id="tocSlastaccounts"></a>
+<a id="tocslastaccounts"></a>
+
+```json
+{
+  "made_up_to": "2020-04-08",
+  "period_start_on": "2020-04-08",
+  "period_end_on": "2020-04-08",
+  "type": "null"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|made_up_to|string(date)|true|none|Deprecated. Please use period_end_on.|
+|period_start_on|string(date)|false|none|The first day of the most recently filed accounting period|
+|period_end_on|string(date)|false|none|The last day of the most recently filed accounting period|
+|type|string|true|none|The type of the last company accounts filed.  For enumeration descriptions see `account_type` section in the enumeration mappings.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|null|
+|type|full|
+|type|small|
+|type|medium|
+|type|group|
+|type|dormant|
+|type|interim|
+|type|initial|
+|type|total-exemption-full|
+|type|total-exemption-small|
+|type|partial-exemption|
+|type|audit-exemption-subsidiary|
+|type|filing-exemption-subsidiary|
+|type|micro-entity|
+
+<h3 id="tocS_nextAccounts">nextAccounts</h3>
+<!-- backwards compatibility -->
+<a id="schemanextaccounts"></a>
+<a id="schema_nextAccounts"></a>
+<a id="tocSnextaccounts"></a>
+<a id="tocsnextaccounts"></a>
+
+```json
+{
+  "period_start_on": "2020-04-08",
+  "period_end_on": "2020-04-08",
+  "due_on": "2020-04-08",
+  "overdue": true
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|period_start_on|string(date)|false|none|The first day of the next accounting period to be filed.|
+|period_end_on|string(date)|false|none|The last day of the next accounting period to be filed.|
+|due_on|string(date)|false|none|The date the next company accounts are due.|
+|overdue|boolean|false|none|Flag indicating if the company accounts are overdue.|
+
+<h3 id="tocS_accountPeriodFrom">accountPeriodFrom</h3>
+<!-- backwards compatibility -->
+<a id="schemaaccountperiodfrom"></a>
+<a id="schema_accountPeriodFrom"></a>
+<a id="tocSaccountperiodfrom"></a>
+<a id="tocsaccountperiodfrom"></a>
+
+```json
+{
+  "day": 0,
+  "month": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|day|integer|false|none|Day on which accounting period starts under parent law.|
+|month|integer|false|none|Month in which accounting period starts under parent law.|
+
+<h3 id="tocS_officerSummary">officerSummary</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficersummary"></a>
+<a id="schema_officerSummary"></a>
+<a id="tocSofficersummary"></a>
+<a id="tocsofficersummary"></a>
+
+```json
+{
+  "appointed_on": "2020-04-08",
+  "date_of_birth": [
+    {
+      "day": 0,
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "officer_role": "cic-manager",
+  "name": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|appointed_on|string(date)|true|none|The date the officer was appointed.|
+|date_of_birth|[[dateOfBirth](#schemadateofbirth)]|false|none|Details of director date of birth.|
+|officer_role|string|true|none|For enumeration descriptions see `officer_role` section in the enumeration mappings.|
+|name|string|true|none|Corporate or natural officer name.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|officer_role|cic-manager|
+|officer_role|corporate-director|
+|officer_role|corporate-llp-designated-member|
+|officer_role|corporate-llp-member|
+|officer_role|corporate-manager-of-an-eeig|
+|officer_role|corporate-member-of-a-management-organ|
+|officer_role|corporate-member-of-a-supervisory-organ|
+|officer_role|corporate-member-of-an-administrative-organ|
+|officer_role|corporate-nominee-director|
+|officer_role|corporate-nominee-secretary|
+|officer_role|corporate-secretary|
+|officer_role|director|
+|officer_role|general-partner-in-a-limited-partnership|
+|officer_role|judicial-factor|
+|officer_role|limited-partner-in-a-limited-partnership|
+|officer_role|llp-designated-member|
+|officer_role|llp-member|
+|officer_role|manager-of-an-eeig|
+|officer_role|member-of-a-management-organ|
+|officer_role|member-of-a-supervisory-organ|
+|officer_role|member-of-an-administrative-organ|
+|officer_role|nominee-director|
+|officer_role|nominee-secretary|
+|officer_role|person-authorised-to-accept|
+|officer_role|person-authorised-to-represent|
+|officer_role|person-authorised-to-represent-and-accept|
+|officer_role|receiver-and-manager|
+|officer_role|secretary|
+
+<h3 id="tocS_confirmationOfStatementInformation">confirmationOfStatementInformation</h3>
+<!-- backwards compatibility -->
+<a id="schemaconfirmationofstatementinformation"></a>
+<a id="schema_confirmationOfStatementInformation"></a>
+<a id="tocSconfirmationofstatementinformation"></a>
+<a id="tocsconfirmationofstatementinformation"></a>
+
+```json
+{
+  "last_made_up_to": "2020-04-08",
+  "next_due": "2020-04-08",
+  "next_made_up_to": "2020-04-08",
+  "overdue": true
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|last_made_up_to|string(date)|false|none|The date to which the company last made a confirmation statement.|
+|next_due|string(date)|true|none|The date by which the next confimation statement must be received.|
+|next_made_up_to|string(date)|true|none|The date to which the company must next make a confirmation statement.|
+|overdue|boolean|false|none|Flag indicating if the confirmation statement is overdue.|
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_accountingReferenceDate">accountingReferenceDate</h3>
+<!-- backwards compatibility -->
+<a id="schemaaccountingreferencedate"></a>
+<a id="schema_accountingReferenceDate"></a>
+<a id="tocSaccountingreferencedate"></a>
+<a id="tocsaccountingreferencedate"></a>
+
+```json
+{
+  "day": 0,
+  "month": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|day|integer|true|none|The Accounting Reference Date (ARD) day.|
+|month|integer|true|none|The Accounting Reference Date (ARD) month.|
+
+<h3 id="tocS_accountInformation">accountInformation</h3>
+<!-- backwards compatibility -->
+<a id="schemaaccountinformation"></a>
+<a id="schema_accountInformation"></a>
+<a id="tocSaccountinformation"></a>
+<a id="tocsaccountinformation"></a>
+
+```json
+{
+  "account_period_from": [
+    {
+      "day": 0,
+      "month": 0
+    }
+  ],
+  "account_period_to": [
+    {
+      "day": 0,
+      "month": 0
+    }
+  ],
+  "must_file_within": [
+    {
+      "months": 0
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|account_period_from|[[accountPeriodFrom](#schemaaccountperiodfrom)]|false|none|Date account period starts under parent law.|
+|account_period_to|[[accountPeriodTo](#schemaaccountperiodto)]|false|none|Date account period ends under parent law.|
+|must_file_within|[[fileWithin](#schemafilewithin)]|false|none|Time allowed from period end for disclosure of accounts under parent law.|
+
+<h3 id="tocS_originatingRegistry">originatingRegistry</h3>
+<!-- backwards compatibility -->
+<a id="schemaoriginatingregistry"></a>
+<a id="schema_originatingRegistry"></a>
+<a id="tocSoriginatingregistry"></a>
+<a id="tocsoriginatingregistry"></a>
+
+```json
+{
+  "country": "string",
+  "name": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|country|string|false|none|Country in which company was incorporated.|
+|name|string|false|none|Identity of register in country of incorporation.|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_companyProfile">companyProfile</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanyprofile"></a>
+<a id="schema_companyProfile"></a>
+<a id="tocScompanyprofile"></a>
+<a id="tocscompanyprofile"></a>
+
+```json
+{
+  "accounts": [
+    {
+      "accounting_reference_date": [
+        {
+          "day": 0,
+          "month": 0
+        }
+      ],
+      "last_accounts": [
+        {
+          "made_up_to": "2020-04-08",
+          "period_start_on": "2020-04-08",
+          "period_end_on": "2020-04-08",
+          "type": "null"
+        }
+      ],
+      "next_accounts": [
+        {
+          "period_start_on": "2020-04-08",
+          "period_end_on": "2020-04-08",
+          "due_on": "2020-04-08",
+          "overdue": true
+        }
+      ],
+      "next_due": "2020-04-08",
+      "next_made_up_to": "2020-04-08",
+      "overdue": true
+    }
+  ],
+  "annual_return": [
+    {
+      "last_made_up_to": "2020-04-08",
+      "next_due": "2020-04-08",
+      "next_made_up_to": "2020-04-08",
+      "overdue": true
+    }
+  ],
+  "can_file": true,
+  "confirmation_statement": [
+    {
+      "last_made_up_to": "2020-04-08",
+      "next_due": "2020-04-08",
+      "next_made_up_to": "2020-04-08",
+      "overdue": true
+    }
+  ],
+  "company_name": "string",
+  "company_number": "string",
+  "date_of_creation": "2020-04-08",
+  "date_of_cessation": "2020-04-08",
+  "etag": "string",
+  "has_been_liquidated": true,
+  "has_charges": true,
+  "is_community_interest_company": true,
+  "subtype": "community-interest-company",
+  "jurisdiction": "england-wales",
+  "last_full_members_list_date": "2020-04-08",
+  "foreign_company_details": [
+    {
+      "originating_registry": [
+        {
+          "country": "string",
+          "name": "string"
+        }
+      ],
+      "registration_number": "string",
+      "governed_by": "string",
+      "company_type": "string",
+      "is_a_credit_finance_institution": true,
+      "accounts": [
+        {
+          "account_period_from": [
+            {
+              "day": 0,
+              "month": 0
+            }
+          ],
+          "account_period_to": [
+            {
+              "day": 0,
+              "month": 0
+            }
+          ],
+          "must_file_within": [
+            {
+              "months": 0
+            }
+          ]
+        }
+      ],
+      "business_activity": "string",
+      "accounting_requirement": "string"
+    }
+  ],
+  "registered_office_address": [
+    {
+      "care_of": "string",
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "country": "Wales",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "sic_codes": [
+    "string"
+  ],
+  "previous_company_names": [
+    {
+      "name": "string",
+      "effective_from": "2020-04-08",
+      "ceased_on": "2020-04-08"
+    }
+  ],
+  "company_status": "active",
+  "company_status_detail": "transferred-from-uk",
+  "type": "private-unlimited",
+  "external_registration_number": "string",
+  "has_insolvency_history": true,
+  "undeliverable_registered_office_address": true,
+  "registered_office_is_in_dispute": true,
+  "branch_company_details": [
+    {
+      "business_activity": "string",
+      "parent_company_number": "string",
+      "parent_company_name": "string"
+    }
+  ],
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control": "string",
+      "persons_with_significant_control_statements": "string",
+      "filing_history": "string",
+      "officers": "string",
+      "insolvency": "string",
+      "charges": "string",
+      "registers": "string"
+    }
+  ],
+  "partial_data_available": "full-data-available-from-financial-conduct-authority"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|accounts|[[accountsInformation](#schemaaccountsinformation)]|false|none|Company accounts information.|
+|annual_return|[[annualReturnInformation](#schemaannualreturninformation)]|false|none|Annual return information. This member is only returned if a confirmation statement has not be filed.|
+|can_file|boolean|true|none|Flag indicating whether this company can file.|
+|confirmation_statement|[[confirmationOfStatementInformation](#schemaconfirmationofstatementinformation)]|false|none|Confirmation statement information.|
+|company_name|string|true|none|The name of the company.|
+|company_number|string|true|none|The number of the company.|
+|date_of_creation|string(date)|false|none|The date when the company was created.|
+|date_of_cessation|string(date)|false|none|The date which the company was converted/closed or dissolved. Please refer to company status to determine which.|
+|etag|string|false|none|The ETag of the resource.|
+|has_been_liquidated|boolean|false|none|The flag indicating if the company has been liquidated in the past.|
+|has_charges|boolean|false|none|Deprecated. Please use links.charges|
+|is_community_interest_company|boolean|false|none|Deprecated. Please use subtype|
+|subtype|string|false|none|The subtype of the company.|
+|jurisdiction|string|true|none|The jurisdiction specifies the political body responsible for the company.|
+|last_full_members_list_date|string(date)|false|none|The date of last full members list update.|
+|foreign_company_details|[[foreignCompanyDetails](#schemaforeigncompanydetails)]|false|none|Foreign company details.|
+|registered_office_address|[[registeredOfficeAddress](#schemaregisteredofficeaddress)]|false|none|The address of the company's registered office.|
+|sic_codes|[string]|false|none|SIC codes for this company.|
+|previous_company_names|[[previousCompanyNames](#schemapreviouscompanynames)]|false|none|The previous names of this company.|
+|company_status|string|false|none|The status of the company.  For enumeration descriptions see `company_status` section in the enumeration mappings.|
+|company_status_detail|string|false|none|Extra details about the status of the company.  For enumeration descriptions see `company_status_detail` section in the enumeration mappings.|
+|type|string|true|none|The type of the company.  For enumeration descriptions see `company_type` section in the enumeration mappings.|
+|external_registration_number|string|false|none|The number given by an external registration body.|
+|has_insolvency_history|boolean|false|none|Deprecated. Please use links.insolvency|
+|undeliverable_registered_office_address|boolean|false|none|Flag indicating whether post can be delivered to the registered office.|
+|registered_office_is_in_dispute|boolean|false|none|Flag indicating registered office address as been replaced.|
+|branch_company_details|[[branchCompanyDetails](#schemabranchcompanydetails)]|false|none|UK branch of a foreign company.|
+|links|[[linksType](#schemalinkstype)]|true|none|A set of URLs related to the resource, including self.|
+|partial_data_available|string|false|none|Returned if Companies House is not the primary source of data for this company.  For enumeration descriptions see `partial_data_available` section in the enumeration mappings.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|subtype|community-interest-company|
+|subtype|private-fund-limited-partnership|
+|jurisdiction|england-wales|
+|jurisdiction|wales|
+|jurisdiction|scotland|
+|jurisdiction|northern-ireland|
+|jurisdiction|european-union|
+|jurisdiction|united-kingdom|
+|jurisdiction|england|
+|jurisdiction|noneu|
+|company_status|active|
+|company_status|dissolved|
+|company_status|liquidation|
+|company_status|receivership|
+|company_status|administration|
+|company_status|voluntary-arrangement|
+|company_status|converted-closed|
+|company_status|insolvency-proceedings|
+|company_status_detail|transferred-from-uk|
+|company_status_detail|active-proposal-to-strike-off|
+|company_status_detail|petition-to-restore-dissolved|
+|company_status_detail|transformed-to-se|
+|company_status_detail|converted-to-plc|
+|type|private-unlimited|
+|type|ltd|
+|type|protected-cell-company|
+|type|plc|
+|type|old-public-company|
+|type|private-limited-guarant-nsc-limited-exemption|
+|type|limited-partnership|
+|type|private-limited-guarant-nsc|
+|type|converted-or-closed|
+|type|private-unlimited-nsc|
+|type|private-limited-shares-section-30-exemption|
+|type|assurance-company|
+|type|oversea-company|
+|type|eeig|
+|type|icvc-securities|
+|type|icvc-warrant|
+|type|icvc-umbrella|
+|type|industrial-and-provident-society|
+|type|northern-ireland|
+|type|northern-ireland-other|
+|type|llp|
+|type|royal-charter|
+|type|investment-company-with-variable-capital|
+|type|unregistered-company|
+|type|other|
+|type|european-public-limited-liability-company-se|
+|type|scottish-partnership|
+|type|charitable-incorporated-organisation|
+|type|scottish-charitable-incorporated-organisation|
+|type|further-education-or-sixth-form-college-corporation|
+|partial_data_available|full-data-available-from-financial-conduct-authority|
+|partial_data_available|full-data-available-from-department-of-the-economy|
+|partial_data_available|full-data-available-from-the-company|
+
+<h3 id="tocS_fileWithin">fileWithin</h3>
+<!-- backwards compatibility -->
+<a id="schemafilewithin"></a>
+<a id="schema_fileWithin"></a>
+<a id="tocSfilewithin"></a>
+<a id="tocsfilewithin"></a>
+
+```json
+{
+  "months": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|months|integer|false|none|Number of months within which to file.|
+
+<h3 id="tocS_accountsRequired">accountsRequired</h3>
+<!-- backwards compatibility -->
+<a id="schemaaccountsrequired"></a>
+<a id="schema_accountsRequired"></a>
+<a id="tocSaccountsrequired"></a>
+<a id="tocsaccountsrequired"></a>
+
+```json
+{
+  "foreign_account_type": "accounting-requirements-of-originating-country-apply",
+  "terms_of_account_publication": "accounts-publication-date-supplied-by-company"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|foreign_account_type|string|false|none|Type of accounting requirement that applies.  For enumeration descriptions see `foreign_account_type` section in the enumeration mappings.|
+|terms_of_account_publication|string|false|none|Describes how the publication date is derived.  For enumeration descriptions see `terms_of_account_publication` section in the enumeration mappings.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|foreign_account_type|accounting-requirements-of-originating-country-apply|
+|foreign_account_type|accounting-requirements-of-originating-country-do-not-apply|
+|terms_of_account_publication|accounts-publication-date-supplied-by-company|
+|terms_of_account_publication|accounting-publication-date-does-not-need-to-be-supplied-by-company|
+|terms_of_account_publication|accounting-reference-date-allocated-by-companies-house|
+
+<h3 id="tocS_registeredOfficeAddress">registeredOfficeAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisteredofficeaddress"></a>
+<a id="schema_registeredOfficeAddress"></a>
+<a id="tocSregisteredofficeaddress"></a>
+<a id="tocsregisteredofficeaddress"></a>
+
+```json
+{
+  "care_of": "string",
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "country": "Wales",
+  "locality": "string",
+  "po_box": "string",
+  "postal_code": "string",
+  "premises": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|care_of|string|false|none|The care of name.|
+|address_line_1|string|false|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|country|string|false|none|The country.|
+|locality|string|false|none|The locality e.g London.|
+|po_box|string|false|none|The post-office box number.|
+|postal_code|string|false|none|The postal code e.g CF14 3UZ.|
+|premises|string|false|none|The property name or number.|
+|region|string|false|none|The region e.g Surrey.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|country|Wales|
+|country|England|
+|country|Scotland|
+|country|Great Britain|
+|country|Not specified|
+|country|United Kingdom|
+|country|Northern Ireland|
+

--- a/openapi3render/markdown_specs/companyRegisters.html.md
+++ b/openapi3render/markdown_specs/companyRegisters.html.md
@@ -1,0 +1,1122 @@
+---
+title: companyRegisters Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="companyregisters-specification">companyRegisters Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="companyregisters-specification-company-company_number-registers">company{company_number}registers</h2>
+
+## readCompanyRegister
+
+<a id="opIdreadCompanyRegister"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/registers \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/registers HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/registers',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/registers',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/registers', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/registers', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/registers");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/registers", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/registers`
+
+*Get the company registers information*
+
+<h4 id="readcompanyregister-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the register information to return.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "company_number": "string",
+  "kind": "registers",
+  "registers": [
+    {
+      "directors": [
+        {
+          "register_type": "directors",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "secretaries": [
+        {
+          "register_type": "secretaries",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "persons_with_significant_control": [
+        {
+          "register_type": "persons-with-significant-control",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "usual_residential_address": [
+        {
+          "register_type": "usual-residential-address",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "llp_usual_residential_address": [
+        {
+          "register_type": "llp-usual-residential-address",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "members": [
+        {
+          "register_type": "members",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "llp_members": [
+        {
+          "register_type": "llp-members",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ]
+    }
+  ],
+  "etag": "string"
+}
+```
+
+<h4 id="readcompanyregister-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[companyRegister](#schemacompanyregister)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_registerListLLPUsualResidentialAddress">registerListLLPUsualResidentialAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisterlistllpusualresidentialaddress"></a>
+<a id="schema_registerListLLPUsualResidentialAddress"></a>
+<a id="tocSregisterlistllpusualresidentialaddress"></a>
+<a id="tocsregisterlistllpusualresidentialaddress"></a>
+
+```json
+{
+  "register_type": "llp-usual-residential-address",
+  "items": [
+    {
+      "moved_on": "2020-04-08",
+      "register_moved_to": "public-register",
+      "links": {}
+    }
+  ],
+  "links": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|register_type|string|true|none|The register type.|
+|items|[[registeredItems](#schemaregistereditems)]|true|none|[Registered details for the company]|
+|links|object|false|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_type|llp-usual-residential-address|
+
+<h3 id="tocS_linksListLLPUsualResidentialAddress">linksListLLPUsualResidentialAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkslistllpusualresidentialaddress"></a>
+<a id="schema_linksListLLPUsualResidentialAddress"></a>
+<a id="tocSlinkslistllpusualresidentialaddress"></a>
+<a id="tocslinkslistllpusualresidentialaddress"></a>
+
+```json
+{
+  "llp_usual_residential_address": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|llp_usual_residential_address|string|false|none|The URL for the resource.|
+
+<h3 id="tocS_registerListPersonsWithSignificantControl">registerListPersonsWithSignificantControl</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisterlistpersonswithsignificantcontrol"></a>
+<a id="schema_registerListPersonsWithSignificantControl"></a>
+<a id="tocSregisterlistpersonswithsignificantcontrol"></a>
+<a id="tocsregisterlistpersonswithsignificantcontrol"></a>
+
+```json
+{
+  "register_type": "persons-with-significant-control",
+  "items": [
+    {
+      "moved_on": "2020-04-08",
+      "register_moved_to": "public-register",
+      "links": {}
+    }
+  ],
+  "links": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|register_type|string|true|none|The register type.|
+|items|[[registeredItems](#schemaregistereditems)]|true|none|[Registered details for the company]|
+|links|object|false|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_type|persons-with-significant-control|
+
+<h3 id="tocS_linksListLLPMembers">linksListLLPMembers</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkslistllpmembers"></a>
+<a id="schema_linksListLLPMembers"></a>
+<a id="tocSlinkslistllpmembers"></a>
+<a id="tocslinkslistllpmembers"></a>
+
+```json
+{
+  "llp_members": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|llp_members|string|false|none|The URL for the resource.|
+
+<h3 id="tocS_linksListUsualResidentialAddress">linksListUsualResidentialAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkslistusualresidentialaddress"></a>
+<a id="schema_linksListUsualResidentialAddress"></a>
+<a id="tocSlinkslistusualresidentialaddress"></a>
+<a id="tocslinkslistusualresidentialaddress"></a>
+
+```json
+{
+  "usual_residential_address": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|usual_residential_address|string|false|none|The URL for the resource.|
+
+<h3 id="tocS_linksItems">linksItems</h3>
+<!-- backwards compatibility -->
+<a id="schemalinksitems"></a>
+<a id="schema_linksItems"></a>
+<a id="tocSlinksitems"></a>
+<a id="tocslinksitems"></a>
+
+```json
+{
+  "filing": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|filing|string|true|none|The URL of the transaction for the resource.|
+
+<h3 id="tocS_linksDirectorsRegister">linksDirectorsRegister</h3>
+<!-- backwards compatibility -->
+<a id="schemalinksdirectorsregister"></a>
+<a id="schema_linksDirectorsRegister"></a>
+<a id="tocSlinksdirectorsregister"></a>
+<a id="tocslinksdirectorsregister"></a>
+
+```json
+{
+  "directors_register": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|directors_register|string|false|none|The URL for the resource.|
+
+<h3 id="tocS_registerListDirectors">registerListDirectors</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisterlistdirectors"></a>
+<a id="schema_registerListDirectors"></a>
+<a id="tocSregisterlistdirectors"></a>
+<a id="tocsregisterlistdirectors"></a>
+
+```json
+{
+  "register_type": "directors",
+  "items": [
+    {
+      "moved_on": "2020-04-08",
+      "register_moved_to": "public-register",
+      "links": {}
+    }
+  ],
+  "links": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|register_type|string|true|none|The register type.|
+|items|[[registeredItems](#schemaregistereditems)]|true|none|[Registered details for the company]|
+|links|object|false|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_type|directors|
+
+<h3 id="tocS_linksSecretaryRegister">linksSecretaryRegister</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkssecretaryregister"></a>
+<a id="schema_linksSecretaryRegister"></a>
+<a id="tocSlinkssecretaryregister"></a>
+<a id="tocslinkssecretaryregister"></a>
+
+```json
+{
+  "secretaries_register": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|secretaries_register|string|false|none|The URL for the resource.|
+
+<h3 id="tocS_linksType">linksType</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkstype"></a>
+<a id="schema_linksType"></a>
+<a id="tocSlinkstype"></a>
+<a id="tocslinkstype"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of the resource.|
+
+<h3 id="tocS_registerListUsualResidentialAddress">registerListUsualResidentialAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisterlistusualresidentialaddress"></a>
+<a id="schema_registerListUsualResidentialAddress"></a>
+<a id="tocSregisterlistusualresidentialaddress"></a>
+<a id="tocsregisterlistusualresidentialaddress"></a>
+
+```json
+{
+  "register_type": "usual-residential-address",
+  "items": [
+    {
+      "moved_on": "2020-04-08",
+      "register_moved_to": "public-register",
+      "links": {}
+    }
+  ],
+  "links": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|register_type|string|true|none|The register type.|
+|items|[[registeredItems](#schemaregistereditems)]|true|none|[Registered details for the company]|
+|links|object|false|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_type|usual-residential-address|
+
+<h3 id="tocS_companyRegister">companyRegister</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanyregister"></a>
+<a id="schema_companyRegister"></a>
+<a id="tocScompanyregister"></a>
+<a id="tocscompanyregister"></a>
+
+```json
+{
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "company_number": "string",
+  "kind": "registers",
+  "registers": [
+    {
+      "directors": [
+        {
+          "register_type": "directors",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "secretaries": [
+        {
+          "register_type": "secretaries",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "persons_with_significant_control": [
+        {
+          "register_type": "persons-with-significant-control",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "usual_residential_address": [
+        {
+          "register_type": "usual-residential-address",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "llp_usual_residential_address": [
+        {
+          "register_type": "llp-usual-residential-address",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "members": [
+        {
+          "register_type": "members",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ],
+      "llp_members": [
+        {
+          "register_type": "llp-members",
+          "items": [
+            {
+              "moved_on": "2020-04-08",
+              "register_moved_to": "public-register",
+              "links": {}
+            }
+          ],
+          "links": {}
+        }
+      ]
+    }
+  ],
+  "etag": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|links|[[linksType](#schemalinkstype)]|true|none|A set of URLs related to the resource, including self.|
+|company_number|string|true|none|The number of the company.|
+|kind|string|true|none|none|
+|registers|[[registers](#schemaregisters)]|true|none|company registers information.|
+|etag|string|false|none|The ETag of the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|registers|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_registerListMembers">registerListMembers</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisterlistmembers"></a>
+<a id="schema_registerListMembers"></a>
+<a id="tocSregisterlistmembers"></a>
+<a id="tocsregisterlistmembers"></a>
+
+```json
+{
+  "register_type": "members",
+  "items": [
+    {
+      "moved_on": "2020-04-08",
+      "register_moved_to": "public-register",
+      "links": {}
+    }
+  ],
+  "links": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|register_type|string|true|none|The register type.|
+|items|[[registeredItems](#schemaregistereditems)]|true|none|[Registered details for the company]|
+|links|object|false|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_type|members|
+
+<h3 id="tocS_linksListMembers">linksListMembers</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkslistmembers"></a>
+<a id="schema_linksListMembers"></a>
+<a id="tocSlinkslistmembers"></a>
+<a id="tocslinkslistmembers"></a>
+
+```json
+{
+  "members": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|members|string|false|none|The URL for the resource.|
+
+<h3 id="tocS_registeredItems">registeredItems</h3>
+<!-- backwards compatibility -->
+<a id="schemaregistereditems"></a>
+<a id="schema_registeredItems"></a>
+<a id="tocSregistereditems"></a>
+<a id="tocsregistereditems"></a>
+
+```json
+{
+  "moved_on": "2020-04-08",
+  "register_moved_to": "public-register",
+  "links": {}
+}
+
+```
+
+Registered details for the company
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|moved_on|string(date)|true|none|The date registered on|
+|register_moved_to|string|true|none|Location of registration|
+|links|object|true|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_moved_to|public-register|
+|register_moved_to|registered-office|
+|register_moved_to|single-alternative-inspection-location|
+|register_moved_to|unspecified-location|
+
+<h3 id="tocS_linksPersonsWithSignificantControlRegister">linksPersonsWithSignificantControlRegister</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkspersonswithsignificantcontrolregister"></a>
+<a id="schema_linksPersonsWithSignificantControlRegister"></a>
+<a id="tocSlinkspersonswithsignificantcontrolregister"></a>
+<a id="tocslinkspersonswithsignificantcontrolregister"></a>
+
+```json
+{
+  "persons_with_significant_control_register": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|persons_with_significant_control_register|string|false|none|The URL for the resource.|
+
+<h3 id="tocS_registers">registers</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisters"></a>
+<a id="schema_registers"></a>
+<a id="tocSregisters"></a>
+<a id="tocsregisters"></a>
+
+```json
+{
+  "directors": [
+    {
+      "register_type": "directors",
+      "items": [
+        {
+          "moved_on": "2020-04-08",
+          "register_moved_to": "public-register",
+          "links": {}
+        }
+      ],
+      "links": {}
+    }
+  ],
+  "secretaries": [
+    {
+      "register_type": "secretaries",
+      "items": [
+        {
+          "moved_on": "2020-04-08",
+          "register_moved_to": "public-register",
+          "links": {}
+        }
+      ],
+      "links": {}
+    }
+  ],
+  "persons_with_significant_control": [
+    {
+      "register_type": "persons-with-significant-control",
+      "items": [
+        {
+          "moved_on": "2020-04-08",
+          "register_moved_to": "public-register",
+          "links": {}
+        }
+      ],
+      "links": {}
+    }
+  ],
+  "usual_residential_address": [
+    {
+      "register_type": "usual-residential-address",
+      "items": [
+        {
+          "moved_on": "2020-04-08",
+          "register_moved_to": "public-register",
+          "links": {}
+        }
+      ],
+      "links": {}
+    }
+  ],
+  "llp_usual_residential_address": [
+    {
+      "register_type": "llp-usual-residential-address",
+      "items": [
+        {
+          "moved_on": "2020-04-08",
+          "register_moved_to": "public-register",
+          "links": {}
+        }
+      ],
+      "links": {}
+    }
+  ],
+  "members": [
+    {
+      "register_type": "members",
+      "items": [
+        {
+          "moved_on": "2020-04-08",
+          "register_moved_to": "public-register",
+          "links": {}
+        }
+      ],
+      "links": {}
+    }
+  ],
+  "llp_members": [
+    {
+      "register_type": "llp-members",
+      "items": [
+        {
+          "moved_on": "2020-04-08",
+          "register_moved_to": "public-register",
+          "links": {}
+        }
+      ],
+      "links": {}
+    }
+  ]
+}
+
+```
+
+Registered company information.
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|directors|[[registerListDirectors](#schemaregisterlistdirectors)]|true|none|List of registered company directors|
+|secretaries|[[registerListSecretaries](#schemaregisterlistsecretaries)]|true|none|List of registered company secretaries.|
+|persons_with_significant_control|[[registerListPersonsWithSignificantControl](#schemaregisterlistpersonswithsignificantcontrol)]|true|none|List of registered company persons with significant control.|
+|usual_residential_address|[[registerListUsualResidentialAddress](#schemaregisterlistusualresidentialaddress)]|true|none|List of register addresses.|
+|llp_usual_residential_address|[[registerListLLPUsualResidentialAddress](#schemaregisterlistllpusualresidentialaddress)]|false|none|List of register addresses.|
+|members|[[registerListMembers](#schemaregisterlistmembers)]|true|none|List of registered company members.|
+|llp_members|[[registerListLLPMembers](#schemaregisterlistllpmembers)]|false|none|List of registered llp members.|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_registerListLLPMembers">registerListLLPMembers</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisterlistllpmembers"></a>
+<a id="schema_registerListLLPMembers"></a>
+<a id="tocSregisterlistllpmembers"></a>
+<a id="tocsregisterlistllpmembers"></a>
+
+```json
+{
+  "register_type": "llp-members",
+  "items": [
+    {
+      "moved_on": "2020-04-08",
+      "register_moved_to": "public-register",
+      "links": {}
+    }
+  ],
+  "links": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|register_type|string|true|none|The register type.|
+|items|[[registeredItems](#schemaregistereditems)]|true|none|[Registered details for the company]|
+|links|object|false|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_type|llp-members|
+
+<h3 id="tocS_registerListSecretaries">registerListSecretaries</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisterlistsecretaries"></a>
+<a id="schema_registerListSecretaries"></a>
+<a id="tocSregisterlistsecretaries"></a>
+<a id="tocsregisterlistsecretaries"></a>
+
+```json
+{
+  "register_type": "secretaries",
+  "items": [
+    {
+      "moved_on": "2020-04-08",
+      "register_moved_to": "public-register",
+      "links": {}
+    }
+  ],
+  "links": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|register_type|string|true|none|The register type.|
+|items|[[registeredItems](#schemaregistereditems)]|true|none|[Registered details for the company]|
+|links|object|false|none|A set of URLs related to the resource.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|register_type|secretaries|
+

--- a/openapi3render/markdown_specs/companyUKEstablishments.html.md
+++ b/openapi3render/markdown_specs/companyUKEstablishments.html.md
@@ -1,0 +1,351 @@
+---
+title: companyUKEstablishments Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="companyukestablishments-specification">companyUKEstablishments Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="companyukestablishments-specification-company-company_number-uk-establishments">company{company_number}uk-establishments</h2>
+
+## getCompanyUKEstablishments
+
+<a id="opIdgetCompanyUKEstablishments"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/uk-establishments \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/uk-establishments HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/uk-establishments',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/uk-establishments',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/uk-establishments', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/uk-establishments', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/uk-establishments");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/uk-establishments", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/uk-establishments`
+
+*Get a list of UK Establishment companies*
+
+<h4 id="getcompanyukestablishments-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|Company number.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "kind": "ukestablishment-companies",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "items": [
+    {
+      "company_number": "string",
+      "company_name": "string",
+      "company_status": "string",
+      "locality": "string",
+      "links": [
+        {
+          "company": "string"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<h4 id="getcompanyukestablishments-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[companyUKEstablishments](#schemacompanyukestablishments)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid request|None|
+
+<h4 id="getcompanyukestablishments-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_self_links">self_links</h3>
+<!-- backwards compatibility -->
+<a id="schemaself_links"></a>
+<a id="schema_self_links"></a>
+<a id="tocSself_links"></a>
+<a id="tocsself_links"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|false|none|Link to this company.|
+
+<h3 id="tocS_companyUKEstablishments">companyUKEstablishments</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanyukestablishments"></a>
+<a id="schema_companyUKEstablishments"></a>
+<a id="tocScompanyukestablishments"></a>
+<a id="tocscompanyukestablishments"></a>
+
+```json
+{
+  "etag": "string",
+  "kind": "ukestablishment-companies",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "items": [
+    {
+      "company_number": "string",
+      "company_name": "string",
+      "company_status": "string",
+      "locality": "string",
+      "links": [
+        {
+          "company": "string"
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|false|none|The ETag of the resource.|
+|kind|string|false|none|UK Establishment companies.|
+|links|[[self_links](#schemaself_links)]|false|none|UK Establishment Resources related to this company.|
+|items|[[companyDetails](#schemacompanydetails)]|false|none|List of UK Establishment companies|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|ukestablishment-companies|
+
+<h3 id="tocS_companyDetails">companyDetails</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanydetails"></a>
+<a id="schema_companyDetails"></a>
+<a id="tocScompanydetails"></a>
+<a id="tocscompanydetails"></a>
+
+```json
+{
+  "company_number": "string",
+  "company_name": "string",
+  "company_status": "string",
+  "locality": "string",
+  "links": [
+    {
+      "company": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|company_number|string|true|none|The number of the company.|
+|company_name|string|true|none|The name of the company.|
+|company_status|string|true|none|company status.|
+|locality|string|false|none|The locality e.g London.|
+|links|[[links](#schemalinks)]|true|none|Resources related to this company.|
+
+<h3 id="tocS_links">links</h3>
+<!-- backwards compatibility -->
+<a id="schemalinks"></a>
+<a id="schema_links"></a>
+<a id="tocSlinks"></a>
+<a id="tocslinks"></a>
+
+```json
+{
+  "company": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|company|string|false|none|The link to the company.|
+

--- a/openapi3render/markdown_specs/disqualifications.html.md
+++ b/openapi3render/markdown_specs/disqualifications.html.md
@@ -1,0 +1,987 @@
+---
+title: disqualifications Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="disqualifications-specification">disqualifications Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="disqualifications-specification-disqualified-officers">disqualified-officers</h2>
+
+## naturalDisqualification
+
+<a id="opIdnaturalDisqualification"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/disqualified-officers/natural/{officer_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/disqualified-officers/natural/{officer_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/disqualified-officers/natural/{officer_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/disqualified-officers/natural/{officer_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/disqualified-officers/natural/{officer_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/disqualified-officers/natural/{officer_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/disqualified-officers/natural/{officer_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/disqualified-officers/natural/{officer_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /disqualified-officers/natural/{officer_id}`
+
+*Get a natural officer's disqualifications*
+
+<h4 id="naturaldisqualification-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|officer_id|path|string|true|The disqualified officer's id.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "date_of_birth": "2020-04-08",
+  "etag": "string",
+  "forename": "string",
+  "honours": "string",
+  "kind": "natural-disqualification",
+  "nationality": "string",
+  "other_forenames": "string",
+  "surname": "string",
+  "title": "string",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "disqualifications": [
+    {
+      "case_identifier": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "country": "string",
+          "locality": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "disqualification_type": "string",
+      "disqualified_from": "2020-04-08",
+      "disqualified_until": "2020-04-08",
+      "heard_on": "2020-04-08",
+      "undertaken_on": "2020-04-08",
+      "last_variation": [
+        {
+          "varied_on": "2020-04-08",
+          "case_identifier": "string",
+          "court_name": "string"
+        }
+      ],
+      "reason": [
+        {
+          "description_identifier": "string",
+          "act": "string",
+          "article": "string",
+          "section": "string"
+        }
+      ]
+    }
+  ],
+  "permissions_to_act": [
+    {
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "expires_on": "2020-04-08",
+      "granted_on": "2020-04-08"
+    }
+  ]
+}
+```
+
+<h4 id="naturaldisqualification-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[naturalDisqualification](#schemanaturaldisqualification)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## corporateDisqualification
+
+<a id="opIdcorporateDisqualification"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/disqualified-officers/corporate/{officer_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/disqualified-officers/corporate/{officer_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/disqualified-officers/corporate/{officer_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/disqualified-officers/corporate/{officer_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/disqualified-officers/corporate/{officer_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/disqualified-officers/corporate/{officer_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/disqualified-officers/corporate/{officer_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/disqualified-officers/corporate/{officer_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /disqualified-officers/corporate/{officer_id}`
+
+*Get a corporate officer's disqualifications*
+
+<h4 id="corporatedisqualification-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|officer_id|path|string|true|The disqualified officer id.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "company_number": "string",
+  "country_of_registration": "string",
+  "etag": "string",
+  "kind": "corporate-disqualification",
+  "name": "string",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "disqualifications": [
+    {
+      "case_identifier": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "country": "string",
+          "locality": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "disqualification_type": "string",
+      "disqualified_from": "2020-04-08",
+      "disqualified_until": "2020-04-08",
+      "heard_on": "2020-04-08",
+      "undertaken_on": "2020-04-08",
+      "last_variation": [
+        {
+          "varied_on": "2020-04-08",
+          "case_identifier": "string",
+          "court_name": "string"
+        }
+      ],
+      "reason": [
+        {
+          "description_identifier": "string",
+          "act": "string",
+          "article": "string",
+          "section": "string"
+        }
+      ]
+    }
+  ],
+  "permissions_to_act": [
+    {
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "expires_on": "2020-04-08",
+      "granted_on": "2020-04-08"
+    }
+  ]
+}
+```
+
+<h4 id="corporatedisqualification-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[corporateDisqualification](#schemacorporatedisqualification)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_reason">reason</h3>
+<!-- backwards compatibility -->
+<a id="schemareason"></a>
+<a id="schema_reason"></a>
+<a id="tocSreason"></a>
+<a id="tocsreason"></a>
+
+```json
+{
+  "description_identifier": "string",
+  "act": "string",
+  "article": "string",
+  "section": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|description_identifier|string|true|none|An enumeration type that provides the description for the reason of disqualification.|
+|act|string|true|none|An enumeration type that provides the law under which the disqualification was made.|
+|article|string|false|none|The article of the act under which the disqualification was made.|
+|section|string|false|none|The section of the act under which the disqualification was made.|
+
+<h3 id="tocS_address">address</h3>
+<!-- backwards compatibility -->
+<a id="schemaaddress"></a>
+<a id="schema_address"></a>
+<a id="tocSaddress"></a>
+<a id="tocsaddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "country": "string",
+  "locality": "string",
+  "postal_code": "string",
+  "premises": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|false|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|country|string|false|none|The country. For example, UK.|
+|locality|string|false|none|The locality. For example London.|
+|postal_code|string|false|none|The postal code. For example CF14 3UZ.|
+|premises|string|false|none|The property name or number.|
+|region|string|false|none|The region. For example Surrey.|
+
+<h3 id="tocS_corporateDisqualification">corporateDisqualification</h3>
+<!-- backwards compatibility -->
+<a id="schemacorporatedisqualification"></a>
+<a id="schema_corporateDisqualification"></a>
+<a id="tocScorporatedisqualification"></a>
+<a id="tocscorporatedisqualification"></a>
+
+```json
+{
+  "company_number": "string",
+  "country_of_registration": "string",
+  "etag": "string",
+  "kind": "corporate-disqualification",
+  "name": "string",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "disqualifications": [
+    {
+      "case_identifier": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "country": "string",
+          "locality": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "disqualification_type": "string",
+      "disqualified_from": "2020-04-08",
+      "disqualified_until": "2020-04-08",
+      "heard_on": "2020-04-08",
+      "undertaken_on": "2020-04-08",
+      "last_variation": [
+        {
+          "varied_on": "2020-04-08",
+          "case_identifier": "string",
+          "court_name": "string"
+        }
+      ],
+      "reason": [
+        {
+          "description_identifier": "string",
+          "act": "string",
+          "article": "string",
+          "section": "string"
+        }
+      ]
+    }
+  ],
+  "permissions_to_act": [
+    {
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "expires_on": "2020-04-08",
+      "granted_on": "2020-04-08"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|company_number|string|false|none|The registration number of the disqualified officer.|
+|country_of_registration|string|false|none|The country in which the disqualified officer was registered.|
+|etag|string|true|none|The ETag of the resource.|
+|kind|string|true|none|none|
+|name|string|true|none|The name of the disqualified officer.|
+|links|[[links](#schemalinks)]|true|none|Links to other resources associated with this officer disqualification resource.|
+|disqualifications|[[disqualification](#schemadisqualification)]|true|none|The officer's disqualifications.|
+|permissions_to_act|[[permission_to_act](#schemapermission_to_act)]|false|none|Permissions that the disqualified officer has to act outside of their disqualification.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|corporate-disqualification|
+
+<h3 id="tocS_naturalDisqualification">naturalDisqualification</h3>
+<!-- backwards compatibility -->
+<a id="schemanaturaldisqualification"></a>
+<a id="schema_naturalDisqualification"></a>
+<a id="tocSnaturaldisqualification"></a>
+<a id="tocsnaturaldisqualification"></a>
+
+```json
+{
+  "date_of_birth": "2020-04-08",
+  "etag": "string",
+  "forename": "string",
+  "honours": "string",
+  "kind": "natural-disqualification",
+  "nationality": "string",
+  "other_forenames": "string",
+  "surname": "string",
+  "title": "string",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "disqualifications": [
+    {
+      "case_identifier": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "country": "string",
+          "locality": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "disqualification_type": "string",
+      "disqualified_from": "2020-04-08",
+      "disqualified_until": "2020-04-08",
+      "heard_on": "2020-04-08",
+      "undertaken_on": "2020-04-08",
+      "last_variation": [
+        {
+          "varied_on": "2020-04-08",
+          "case_identifier": "string",
+          "court_name": "string"
+        }
+      ],
+      "reason": [
+        {
+          "description_identifier": "string",
+          "act": "string",
+          "article": "string",
+          "section": "string"
+        }
+      ]
+    }
+  ],
+  "permissions_to_act": [
+    {
+      "company_names": [
+        "string"
+      ],
+      "court_name": "string",
+      "expires_on": "2020-04-08",
+      "granted_on": "2020-04-08"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|date_of_birth|string(date)|false|none|The disqualified officer's date of birth.|
+|etag|string|true|none|The ETag of the resource.|
+|forename|string|false|none|The forename of the disqualified officer.|
+|honours|string|false|none|The honours that the disqualified officer has.|
+|kind|string|true|none|none|
+|nationality|string|false|none|The nationality of the disqualified officer.|
+|other_forenames|string|false|none|The other forenames of the disqualified officer.|
+|surname|string|true|none|The surname of the disqualified officer.|
+|title|string|false|none|The title of the disqualified officer.|
+|links|[[links](#schemalinks)]|true|none|Links to other resources associated with this officer disqualification resource.|
+|disqualifications|[[disqualification](#schemadisqualification)]|true|none|The officer's disqualifications.|
+|permissions_to_act|[[permission_to_act](#schemapermission_to_act)]|false|none|Permissions to act that have been granted for the disqualified officer.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|natural-disqualification|
+
+<h3 id="tocS_disqualification">disqualification</h3>
+<!-- backwards compatibility -->
+<a id="schemadisqualification"></a>
+<a id="schema_disqualification"></a>
+<a id="tocSdisqualification"></a>
+<a id="tocsdisqualification"></a>
+
+```json
+{
+  "case_identifier": "string",
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "country": "string",
+      "locality": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "company_names": [
+    "string"
+  ],
+  "court_name": "string",
+  "disqualification_type": "string",
+  "disqualified_from": "2020-04-08",
+  "disqualified_until": "2020-04-08",
+  "heard_on": "2020-04-08",
+  "undertaken_on": "2020-04-08",
+  "last_variation": [
+    {
+      "varied_on": "2020-04-08",
+      "case_identifier": "string",
+      "court_name": "string"
+    }
+  ],
+  "reason": [
+    {
+      "description_identifier": "string",
+      "act": "string",
+      "article": "string",
+      "section": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|case_identifier|string|false|none|The case identifier of the disqualification.|
+|address|[[address](#schemaaddress)]|true|none|The address of the disqualified officer as provided by the disqualifying authority.|
+|company_names|[string]|false|none|The companies in which the misconduct took place.|
+|court_name|string|false|none|The name of the court that handled the disqualification case.|
+|disqualification_type|string|true|none|An enumeration type that provides the disqualifying authority that handled the disqualification case.|
+|disqualified_from|string(date)|true|none|The date that the disqualification starts.|
+|disqualified_until|string(date)|true|none|The date that the disqualification ends.|
+|heard_on|string(date)|false|none|The date the disqualification hearing was on.|
+|undertaken_on|string(date)|false|none|The date the disqualification undertaking was agreed on.|
+|last_variation|[[last_variation](#schemalast_variation)]|false|none|The latest variation made to the disqualification.|
+|reason|[[reason](#schemareason)]|true|none|The reason for the disqualification.|
+
+<h3 id="tocS_last_variation">last_variation</h3>
+<!-- backwards compatibility -->
+<a id="schemalast_variation"></a>
+<a id="schema_last_variation"></a>
+<a id="tocSlast_variation"></a>
+<a id="tocslast_variation"></a>
+
+```json
+{
+  "varied_on": "2020-04-08",
+  "case_identifier": "string",
+  "court_name": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|varied_on|string(date)|false|none|The date the variation was made against the disqualification.|
+|case_identifier|string|false|none|The case identifier of the variation.|
+|court_name|string|false|none|The name of the court that handled the variation case.|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_links">links</h3>
+<!-- backwards compatibility -->
+<a id="schemalinks"></a>
+<a id="schema_links"></a>
+<a id="tocSlinks"></a>
+<a id="tocslinks"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|Link to this disqualification resource.|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_permission_to_act">permission_to_act</h3>
+<!-- backwards compatibility -->
+<a id="schemapermission_to_act"></a>
+<a id="schema_permission_to_act"></a>
+<a id="tocSpermission_to_act"></a>
+<a id="tocspermission_to_act"></a>
+
+```json
+{
+  "company_names": [
+    "string"
+  ],
+  "court_name": "string",
+  "expires_on": "2020-04-08",
+  "granted_on": "2020-04-08"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|company_names|[string]|false|none|The companies for which the disqualified officer has permission to act.|
+|court_name|string|false|none|The name of the court that granted the permission to act.|
+|expires_on|string(date)|true|none|The date that the permission ends.|
+|granted_on|string(date)|true|none|The date that the permission starts.|
+

--- a/openapi3render/markdown_specs/exemptions.html.md
+++ b/openapi3render/markdown_specs/exemptions.html.md
@@ -1,0 +1,682 @@
+---
+title: exemptions Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="exemptions-specification">exemptions Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="exemptions-specification-company-company_number-exemptions">company{company_number}exemptions</h2>
+
+## readCompanyExemptions
+
+<a id="opIdreadCompanyExemptions"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/exemptions \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/exemptions HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/exemptions',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/exemptions',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/exemptions', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/exemptions', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/exemptions");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/exemptions", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/exemptions`
+
+*Get the company exemptions information.*
+
+<h4 id="readcompanyexemptions-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number that the exemptions list is required for.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "kind": "exemptions",
+  "etag": "string",
+  "exemptions": [
+    {
+      "psc_exempt_as_trading_on_regulated_market": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "psc-exempt-as-trading-on-regulated-market"
+        }
+      ],
+      "psc_exempt_as_shares_admitted_on_market": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "psc-exempt-as-shares-admitted-on-market"
+        }
+      ],
+      "psc_exempt_as_trading_on_uk_regulated_market": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "psc-exempt-as-trading-on-uk-regulated-market"
+        }
+      ],
+      "disclosure_transparency_rules_chapter_five_applies": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "disclosure-transparency-rules-chapter-five-applies"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<h4 id="readcompanyexemptions-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[companyExemptions](#schemacompanyexemptions)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_companyExemptions">companyExemptions</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanyexemptions"></a>
+<a id="schema_companyExemptions"></a>
+<a id="tocScompanyexemptions"></a>
+<a id="tocscompanyexemptions"></a>
+
+```json
+{
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "kind": "exemptions",
+  "etag": "string",
+  "exemptions": [
+    {
+      "psc_exempt_as_trading_on_regulated_market": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "psc-exempt-as-trading-on-regulated-market"
+        }
+      ],
+      "psc_exempt_as_shares_admitted_on_market": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "psc-exempt-as-shares-admitted-on-market"
+        }
+      ],
+      "psc_exempt_as_trading_on_uk_regulated_market": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "psc-exempt-as-trading-on-uk-regulated-market"
+        }
+      ],
+      "disclosure_transparency_rules_chapter_five_applies": [
+        {
+          "items": [
+            {
+              "exempt_from": "2020-04-08",
+              "exempt_to": "2020-04-08"
+            }
+          ],
+          "exemption_type": "disclosure-transparency-rules-chapter-five-applies"
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|links|[[linksType](#schemalinkstype)]|true|none|A set of URLs related to the resource, including self.|
+|kind|string|true|none|none|
+|etag|string|true|none|The ETag of the resource.|
+|exemptions|[[exemptions](#schemaexemptions)]|true|none|Company exemptions information.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|exemptions|
+
+<h3 id="tocS_pscExemptAsSharesAdmittedOnMarketItem">pscExemptAsSharesAdmittedOnMarketItem</h3>
+<!-- backwards compatibility -->
+<a id="schemapscexemptassharesadmittedonmarketitem"></a>
+<a id="schema_pscExemptAsSharesAdmittedOnMarketItem"></a>
+<a id="tocSpscexemptassharesadmittedonmarketitem"></a>
+<a id="tocspscexemptassharesadmittedonmarketitem"></a>
+
+```json
+{
+  "items": [
+    {
+      "exempt_from": "2020-04-08",
+      "exempt_to": "2020-04-08"
+    }
+  ],
+  "exemption_type": "psc-exempt-as-shares-admitted-on-market"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|items|[[exemptionItem](#schemaexemptionitem)]|true|none|List of dates|
+|exemption_type|string|true|none|The exemption type.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|exemption_type|psc-exempt-as-shares-admitted-on-market|
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_pscExemptAsTradingOnRegulatedMarketItem">pscExemptAsTradingOnRegulatedMarketItem</h3>
+<!-- backwards compatibility -->
+<a id="schemapscexemptastradingonregulatedmarketitem"></a>
+<a id="schema_pscExemptAsTradingOnRegulatedMarketItem"></a>
+<a id="tocSpscexemptastradingonregulatedmarketitem"></a>
+<a id="tocspscexemptastradingonregulatedmarketitem"></a>
+
+```json
+{
+  "items": [
+    {
+      "exempt_from": "2020-04-08",
+      "exempt_to": "2020-04-08"
+    }
+  ],
+  "exemption_type": "psc-exempt-as-trading-on-regulated-market"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|items|[[exemptionItem](#schemaexemptionitem)]|true|none|List of dates|
+|exemption_type|string|true|none|The exemption type.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|exemption_type|psc-exempt-as-trading-on-regulated-market|
+
+<h3 id="tocS_exemptions">exemptions</h3>
+<!-- backwards compatibility -->
+<a id="schemaexemptions"></a>
+<a id="schema_exemptions"></a>
+<a id="tocSexemptions"></a>
+<a id="tocsexemptions"></a>
+
+```json
+{
+  "psc_exempt_as_trading_on_regulated_market": [
+    {
+      "items": [
+        {
+          "exempt_from": "2020-04-08",
+          "exempt_to": "2020-04-08"
+        }
+      ],
+      "exemption_type": "psc-exempt-as-trading-on-regulated-market"
+    }
+  ],
+  "psc_exempt_as_shares_admitted_on_market": [
+    {
+      "items": [
+        {
+          "exempt_from": "2020-04-08",
+          "exempt_to": "2020-04-08"
+        }
+      ],
+      "exemption_type": "psc-exempt-as-shares-admitted-on-market"
+    }
+  ],
+  "psc_exempt_as_trading_on_uk_regulated_market": [
+    {
+      "items": [
+        {
+          "exempt_from": "2020-04-08",
+          "exempt_to": "2020-04-08"
+        }
+      ],
+      "exemption_type": "psc-exempt-as-trading-on-uk-regulated-market"
+    }
+  ],
+  "disclosure_transparency_rules_chapter_five_applies": [
+    {
+      "items": [
+        {
+          "exempt_from": "2020-04-08",
+          "exempt_to": "2020-04-08"
+        }
+      ],
+      "exemption_type": "disclosure-transparency-rules-chapter-five-applies"
+    }
+  ]
+}
+
+```
+
+Exemptions information.
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|psc_exempt_as_trading_on_regulated_market|[[pscExemptAsTradingOnRegulatedMarketItem](#schemapscexemptastradingonregulatedmarketitem)]|false|none|If present the company has been or is exempt from keeping a PSC register, as it has voting shares admitted to trading on a regulated market other than the UK.|
+|psc_exempt_as_shares_admitted_on_market|[[pscExemptAsSharesAdmittedOnMarketItem](#schemapscexemptassharesadmittedonmarketitem)]|false|none|If present the company has been or is exempt from keeping a PSC register, as it has voting shares admitted to trading on a market listed in the Register of People with Significant Control Regulations 2016.|
+|psc_exempt_as_trading_on_uk_regulated_market|[[pscExemptAsTradingOnUKRegulatedMarketItem](#schemapscexemptastradingonukregulatedmarketitem)]|false|none|If present the company has been or is exempt from keeping a PSC register, as it has voting shares admitted to trading on a UK regulated market.|
+|disclosure_transparency_rules_chapter_five_applies|[[diclosureTransparencyRulesChapterFiveAppliesItem](#schemadiclosuretransparencyruleschapterfiveappliesitem)]|false|none|If present the company is a traded, DTR5 issuing company. Therefore it may be exempt from updating its PSC information.|
+
+<h3 id="tocS_exemptionItem">exemptionItem</h3>
+<!-- backwards compatibility -->
+<a id="schemaexemptionitem"></a>
+<a id="schema_exemptionItem"></a>
+<a id="tocSexemptionitem"></a>
+<a id="tocsexemptionitem"></a>
+
+```json
+{
+  "exempt_from": "2020-04-08",
+  "exempt_to": "2020-04-08"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|exempt_from|string(date)|true|none|Exemption valid from.|
+|exempt_to|string(date)|false|none|Exemption valid to.|
+
+<h3 id="tocS_pscExemptAsTradingOnUKRegulatedMarketItem">pscExemptAsTradingOnUKRegulatedMarketItem</h3>
+<!-- backwards compatibility -->
+<a id="schemapscexemptastradingonukregulatedmarketitem"></a>
+<a id="schema_pscExemptAsTradingOnUKRegulatedMarketItem"></a>
+<a id="tocSpscexemptastradingonukregulatedmarketitem"></a>
+<a id="tocspscexemptastradingonukregulatedmarketitem"></a>
+
+```json
+{
+  "items": [
+    {
+      "exempt_from": "2020-04-08",
+      "exempt_to": "2020-04-08"
+    }
+  ],
+  "exemption_type": "psc-exempt-as-trading-on-uk-regulated-market"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|items|[[exemptionItem](#schemaexemptionitem)]|true|none|List of dates|
+|exemption_type|string|true|none|The exemption type.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|exemption_type|psc-exempt-as-trading-on-uk-regulated-market|
+
+<h3 id="tocS_linksType">linksType</h3>
+<!-- backwards compatibility -->
+<a id="schemalinkstype"></a>
+<a id="schema_linksType"></a>
+<a id="tocSlinkstype"></a>
+<a id="tocslinkstype"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of this resource.|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_diclosureTransparencyRulesChapterFiveAppliesItem">diclosureTransparencyRulesChapterFiveAppliesItem</h3>
+<!-- backwards compatibility -->
+<a id="schemadiclosuretransparencyruleschapterfiveappliesitem"></a>
+<a id="schema_diclosureTransparencyRulesChapterFiveAppliesItem"></a>
+<a id="tocSdiclosuretransparencyruleschapterfiveappliesitem"></a>
+<a id="tocsdiclosuretransparencyruleschapterfiveappliesitem"></a>
+
+```json
+{
+  "items": [
+    {
+      "exempt_from": "2020-04-08",
+      "exempt_to": "2020-04-08"
+    }
+  ],
+  "exemption_type": "disclosure-transparency-rules-chapter-five-applies"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|items|[[exemptionItem](#schemaexemptionitem)]|true|none|List of exemption periods.|
+|exemption_type|string|true|none|The exemption type.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|exemption_type|disclosure-transparency-rules-chapter-five-applies|
+

--- a/openapi3render/markdown_specs/filingHistory.html.md
+++ b/openapi3render/markdown_specs/filingHistory.html.md
@@ -1,0 +1,827 @@
+---
+title: filingHistory Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="filinghistory-specification">filingHistory Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="filinghistory-specification-company-company_number-filing-history">company{company_number}filing-history</h2>
+
+## getFilingHistoryItem
+
+<a id="opIdgetFilingHistoryItem"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/filing-history/{transaction_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/filing-history/{transaction_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/filing-history/{transaction_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/filing-history/{transaction_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/filing-history/{transaction_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/filing-history/{transaction_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/filing-history/{transaction_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/filing-history/{transaction_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/filing-history/{transaction_id}`
+
+*Get the filing history of the company*
+
+<h4 id="getfilinghistoryitem-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number that the single filing is required for.|
+|transaction_id|path|string|true|The transaction id that the filing history is required for.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "annotations": [
+    {
+      "annotation": "string",
+      "category": "accounts",
+      "date": "2020-04-08",
+      "description": "string",
+      "description_values": {},
+      "type": "string"
+    }
+  ],
+  "associated_filings": [
+    {
+      "category": "accounts",
+      "date": "2020-04-08",
+      "description": "string",
+      "description_values": {},
+      "type": "string"
+    }
+  ],
+  "barcode": "string",
+  "transaction_id": "string",
+  "category": "accounts",
+  "date": "2020-04-08",
+  "description": "string",
+  "description_values": {},
+  "links": {},
+  "pages": 0,
+  "paper_filed": true,
+  "resolutions": [
+    {
+      "category": "miscellaneous",
+      "description": "string",
+      "description_values": {},
+      "document_id": "string",
+      "receive_date": "2020-04-08",
+      "subcategory": "resolution",
+      "type": "string"
+    }
+  ],
+  "subcategory": "resolution",
+  "type": "string"
+}
+```
+
+<h4 id="getfilinghistoryitem-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[filingHistoryItem](#schemafilinghistoryitem)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Filing history not available for this company|None|
+
+<h4 id="getfilinghistoryitem-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## getFilingHistoryList
+
+<a id="opIdgetFilingHistoryList"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/filing-history \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/filing-history HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/filing-history',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/filing-history',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/filing-history', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/filing-history', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/filing-history");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/filing-history", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/filing-history`
+
+*Get the filing history of the company*
+
+<h4 id="getfilinghistorylist-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|category|query|array[string]|false|One or more comma-separated categories to filter by (inclusive).|
+|company_number|path|string|true|The company number that the filing history is required for.|
+|items_per_page|query|integer|false|The number of filing history items to return per page.|
+|start_index|query|integer|false|The index into the entire result set that this result page starts.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "filing_history_status": "filing-history-available",
+  "etag": "string",
+  "items": [
+    {
+      "annotations": [
+        {
+          "annotation": "string",
+          "category": "accounts",
+          "date": "2020-04-08",
+          "description": "string",
+          "description_values": {},
+          "type": "string"
+        }
+      ],
+      "associated_filings": [
+        {
+          "category": "accounts",
+          "date": "2020-04-08",
+          "description": "string",
+          "description_values": {},
+          "type": "string"
+        }
+      ],
+      "barcode": "string",
+      "transaction_id": "string",
+      "category": "accounts",
+      "date": "2020-04-08",
+      "description": "string",
+      "description_values": {},
+      "links": {},
+      "pages": 0,
+      "paper_filed": true,
+      "resolutions": [
+        {
+          "category": "miscellaneous",
+          "description": "string",
+          "description_values": {},
+          "document_id": "string",
+          "receive_date": "2020-04-08",
+          "subcategory": "resolution",
+          "type": "string"
+        }
+      ],
+      "subcategory": "resolution",
+      "type": "string"
+    }
+  ],
+  "items_per_page": 0,
+  "kind": "filing-history",
+  "start_index": 0,
+  "total_count": 0
+}
+```
+
+<h4 id="getfilinghistorylist-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[filingHistoryList](#schemafilinghistorylist)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Filing history not available for this company|None|
+
+<h4 id="getfilinghistorylist-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_annotation">annotation</h3>
+<!-- backwards compatibility -->
+<a id="schemaannotation"></a>
+<a id="schema_annotation"></a>
+<a id="tocSannotation"></a>
+<a id="tocsannotation"></a>
+
+```json
+{
+  "annotation": "string",
+  "category": "accounts",
+  "date": "2020-04-08",
+  "description": "string",
+  "description_values": {},
+  "type": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|annotation|string|false|none|The annotation text.|
+|category|string|false|none|The category of the document filed.|
+|date|string(date)|true|none|The date the annotation was added.|
+|description|string|true|none|A description of the annotation.  For enumeration descriptions see `description` section in the enumeration mappings file.|
+|description_values|object|false|none|Map of data values used to populate place holder id's in the description member|
+|type|string|false|none|The type of filing|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|category|accounts|
+|category|address|
+|category|annual-return|
+|category|capital|
+|category|change-of-name|
+|category|incorporation|
+|category|liquidation|
+|category|miscellaneous|
+|category|mortgage|
+|category|officers|
+|category|resolution|
+
+<h3 id="tocS_descriptionValues">descriptionValues</h3>
+<!-- backwards compatibility -->
+<a id="schemadescriptionvalues"></a>
+<a id="schema_descriptionValues"></a>
+<a id="tocSdescriptionvalues"></a>
+<a id="tocsdescriptionvalues"></a>
+
+```json
+{
+  "key": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|key|object|false|none|A key-value pair|
+
+<h3 id="tocS_filingHistoryItemLinks">filingHistoryItemLinks</h3>
+<!-- backwards compatibility -->
+<a id="schemafilinghistoryitemlinks"></a>
+<a id="schema_filingHistoryItemLinks"></a>
+<a id="tocSfilinghistoryitemlinks"></a>
+<a id="tocsfilinghistoryitemlinks"></a>
+
+```json
+{
+  "self": "string",
+  "document_metadata": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|false|none|Link to this filing history item.|
+|document_metadata|string|false|none|Link to the document metadata associated with this filing history item. See the Document API documentation for more details.|
+
+<h3 id="tocS_filingHistoryList">filingHistoryList</h3>
+<!-- backwards compatibility -->
+<a id="schemafilinghistorylist"></a>
+<a id="schema_filingHistoryList"></a>
+<a id="tocSfilinghistorylist"></a>
+<a id="tocsfilinghistorylist"></a>
+
+```json
+{
+  "filing_history_status": "filing-history-available",
+  "etag": "string",
+  "items": [
+    {
+      "annotations": [
+        {
+          "annotation": "string",
+          "category": "accounts",
+          "date": "2020-04-08",
+          "description": "string",
+          "description_values": {},
+          "type": "string"
+        }
+      ],
+      "associated_filings": [
+        {
+          "category": "accounts",
+          "date": "2020-04-08",
+          "description": "string",
+          "description_values": {},
+          "type": "string"
+        }
+      ],
+      "barcode": "string",
+      "transaction_id": "string",
+      "category": "accounts",
+      "date": "2020-04-08",
+      "description": "string",
+      "description_values": {},
+      "links": {},
+      "pages": 0,
+      "paper_filed": true,
+      "resolutions": [
+        {
+          "category": "miscellaneous",
+          "description": "string",
+          "description_values": {},
+          "document_id": "string",
+          "receive_date": "2020-04-08",
+          "subcategory": "resolution",
+          "type": "string"
+        }
+      ],
+      "subcategory": "resolution",
+      "type": "string"
+    }
+  ],
+  "items_per_page": 0,
+  "kind": "filing-history",
+  "start_index": 0,
+  "total_count": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|filing_history_status|string|false|none|The status of this filing history.|
+|etag|string|true|none|The ETag of the resource.|
+|items|[[filingHistoryItem](#schemafilinghistoryitem)]|true|none|The filing history items|
+|items_per_page|integer|true|none|The number of filing history items returned per page.|
+|kind|string|true|none|Indicates this resource is a filing history.|
+|start_index|integer|true|none|The index into the entire result set that this result page starts.|
+|total_count|integer|true|none|The total number of filing history items for this company.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|filing_history_status|filing-history-available|
+|kind|filing-history|
+
+<h3 id="tocS_resolution">resolution</h3>
+<!-- backwards compatibility -->
+<a id="schemaresolution"></a>
+<a id="schema_resolution"></a>
+<a id="tocSresolution"></a>
+<a id="tocsresolution"></a>
+
+```json
+{
+  "category": "miscellaneous",
+  "description": "string",
+  "description_values": {},
+  "document_id": "string",
+  "receive_date": "2020-04-08",
+  "subcategory": "resolution",
+  "type": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|category|string|true|none|The category of the resolution filed.|
+|description|string|true|none|A description of the associated filing.  For enumeration descriptions see `description` section in the enumeration mappings.|
+|description_values|object|false|none|Map of data values used to populate place holder id's in the description member|
+|document_id|string|false|none|The document id of the resolution.|
+|receive_date|string(date)|true|none|The date the resolution was processed.|
+|subcategory|string|true|none|The sub-category of the document filed.|
+|type|string|true|none|The type of the associated filing.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|category|miscellaneous|
+|subcategory|resolution|
+
+<h3 id="tocS_associatedFiling">associatedFiling</h3>
+<!-- backwards compatibility -->
+<a id="schemaassociatedfiling"></a>
+<a id="schema_associatedFiling"></a>
+<a id="tocSassociatedfiling"></a>
+<a id="tocsassociatedfiling"></a>
+
+```json
+{
+  "category": "accounts",
+  "date": "2020-04-08",
+  "description": "string",
+  "description_values": {},
+  "type": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|category|string|false|none|The category of the document filed.|
+|date|string(date)|true|none|The date the associated filing was processed.|
+|description|string|true|none|A description of the associated filing.  For enumeration descriptions see `description` section in the enumeration mappings.|
+|description_values|object|false|none|Map of data values used to populate place holder id's in the description member|
+|type|string|true|none|The type of the associated filing.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|category|accounts|
+|category|address|
+|category|annual-return|
+|category|capital|
+|category|change-of-name|
+|category|incorporation|
+|category|liquidation|
+|category|miscellaneous|
+|category|mortgage|
+|category|officers|
+|category|resolution|
+
+<h3 id="tocS_filingHistoryItem">filingHistoryItem</h3>
+<!-- backwards compatibility -->
+<a id="schemafilinghistoryitem"></a>
+<a id="schema_filingHistoryItem"></a>
+<a id="tocSfilinghistoryitem"></a>
+<a id="tocsfilinghistoryitem"></a>
+
+```json
+{
+  "annotations": [
+    {
+      "annotation": "string",
+      "category": "accounts",
+      "date": "2020-04-08",
+      "description": "string",
+      "description_values": {},
+      "type": "string"
+    }
+  ],
+  "associated_filings": [
+    {
+      "category": "accounts",
+      "date": "2020-04-08",
+      "description": "string",
+      "description_values": {},
+      "type": "string"
+    }
+  ],
+  "barcode": "string",
+  "transaction_id": "string",
+  "category": "accounts",
+  "date": "2020-04-08",
+  "description": "string",
+  "description_values": {},
+  "links": {},
+  "pages": 0,
+  "paper_filed": true,
+  "resolutions": [
+    {
+      "category": "miscellaneous",
+      "description": "string",
+      "description_values": {},
+      "document_id": "string",
+      "receive_date": "2020-04-08",
+      "subcategory": "resolution",
+      "type": "string"
+    }
+  ],
+  "subcategory": "resolution",
+  "type": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|annotations|[[annotation](#schemaannotation)]|false|none|Annotations for the filing|
+|associated_filings|[[associatedFiling](#schemaassociatedfiling)]|false|none|Any filings associated with the current item|
+|barcode|string|false|none|The barcode of the document.|
+|transaction_id|string|true|none|The transaction ID of the filing.|
+|category|string|true|none|The category of the document filed.|
+|date|string(date)|true|none|The date the filing was processed.|
+|description|string|true|none|A description of the filing.  For enumeration descriptions see `description` section in the enumeration mappings.|
+|description_values|object|false|none|Map of data values used to populate place holder id's in the description member|
+|links|object|false|none|Links to other resources associated with this filing history item.|
+|pages|integer|false|none|Number of pages within the PDF document (links.document_metadata)|
+|paper_filed|boolean|false|none|If true, indicates this is a paper filing.|
+|resolutions|[[resolution](#schemaresolution)]|false|none|Resolutions for the filing|
+|subcategory|string|false|none|The sub-category of the document filed.|
+|type|string|true|none|The type of filing.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|category|accounts|
+|category|address|
+|category|annual-return|
+|category|capital|
+|category|change-of-name|
+|category|incorporation|
+|category|liquidation|
+|category|miscellaneous|
+|category|mortgage|
+|category|officers|
+|category|resolution|
+|subcategory|resolution|
+

--- a/openapi3render/markdown_specs/index.html.md
+++ b/openapi3render/markdown_specs/index.html.md
@@ -1,0 +1,1592 @@
+---
+title: search Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="search-specification">search Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="/">/</a>
+
+<h2 id="search-specification-search-overview">search-overview</h2>
+
+## officersearch
+
+<a id="opIdofficersearch"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET /search/officers?q=string \
+  -H 'Accept: */*'
+
+```
+
+```http
+GET /search/officers?q=string HTTP/1.1
+
+Accept: */*
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'*/*'
+
+};
+
+fetch('/search/officers?q=string',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => '*/*'
+}
+
+result = RestClient.get '/search/officers',
+  params: {
+  'q' => 'string'
+}, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': '*/*'
+}
+
+r = requests.get('/search/officers', params={
+  'q': 'string'
+}, headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => '*/*',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','/search/officers', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("/search/officers?q=string");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"*/*"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "/search/officers", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /search/officers`
+
+*Search company officers*
+
+<h4 id="officersearch-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|q|query|string|true|The term being searched for.|
+|items_per_page|query|integer|false|The number of search results to return per page.|
+|start_index|query|integer|false|The index of the first result item to return.|
+
+> Example responses
+
+> 200 Response
+
+<h4 id="officersearch-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[OfficerSearch](#schemaofficersearch)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid query string supplied.|None|
+
+<h4 id="officersearch-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## search
+
+<a id="opIdsearch"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET /search?q=string \
+  -H 'Accept: */*'
+
+```
+
+```http
+GET /search?q=string HTTP/1.1
+
+Accept: */*
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'*/*'
+
+};
+
+fetch('/search?q=string',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => '*/*'
+}
+
+result = RestClient.get '/search',
+  params: {
+  'q' => 'string'
+}, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': '*/*'
+}
+
+r = requests.get('/search', params={
+  'q': 'string'
+}, headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => '*/*',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','/search', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("/search?q=string");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"*/*"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "/search", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /search`
+
+*Search Companies House*
+
+Search across all indexed information. To search against specific resource types, see <a href="/api/docs/search/companies/companysearch.html">company search</a>, <a href="/api/docs/search/officers/officersearch.html">officer search</a> or <a href="/api/docs/search/disqualified-officers/disqualifiedofficersearch.html">disqualified officer search</a>
+
+<h4 id="search-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|q|query|string|true|The term being searched for.|
+|items_per_page|query|integer|false|The number of search results to return per page.|
+|start_index|query|integer|false|The index of the first result item to return.|
+
+> Example responses
+
+> 200 Response
+
+<h4 id="search-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[Search](#schemasearch)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid query string supplied.|None|
+
+<h4 id="search-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## companysearch
+
+<a id="opIdcompanysearch"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET /search/companies?q=string \
+  -H 'Accept: */*'
+
+```
+
+```http
+GET /search/companies?q=string HTTP/1.1
+
+Accept: */*
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'*/*'
+
+};
+
+fetch('/search/companies?q=string',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => '*/*'
+}
+
+result = RestClient.get '/search/companies',
+  params: {
+  'q' => 'string'
+}, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': '*/*'
+}
+
+r = requests.get('/search/companies', params={
+  'q': 'string'
+}, headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => '*/*',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','/search/companies', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("/search/companies?q=string");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"*/*"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "/search/companies", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /search/companies`
+
+*Search companies*
+
+<h4 id="companysearch-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|q|query|string|true|The term being searched for.|
+|items_per_page|query|integer|false|The number of search results to return per page.|
+|start_index|query|integer|false|The index of the first result item to return.|
+
+> Example responses
+
+> 200 Response
+
+<h4 id="companysearch-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[CompanySearch](#schemacompanysearch)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid query string supplied.|None|
+
+<h4 id="companysearch-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## disqualifiedofficersearch
+
+<a id="opIddisqualifiedofficersearch"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET /search/disqualified-officers?q=string \
+  -H 'Accept: */*'
+
+```
+
+```http
+GET /search/disqualified-officers?q=string HTTP/1.1
+
+Accept: */*
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'*/*'
+
+};
+
+fetch('/search/disqualified-officers?q=string',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => '*/*'
+}
+
+result = RestClient.get '/search/disqualified-officers',
+  params: {
+  'q' => 'string'
+}, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': '*/*'
+}
+
+r = requests.get('/search/disqualified-officers', params={
+  'q': 'string'
+}, headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => '*/*',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','/search/disqualified-officers', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("/search/disqualified-officers?q=string");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"*/*"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "/search/disqualified-officers", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /search/disqualified-officers`
+
+*Search disqualified officers*
+
+<h4 id="disqualifiedofficersearch-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|q|query|string|true|The term being searched for.|
+|items_per_page|query|integer|false|The number of search results to return per page.|
+|start_index|query|integer|false|The index of the first result item to return.|
+
+> Example responses
+
+> 200 Response
+
+<h4 id="disqualifiedofficersearch-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[DisqualifiedOfficerSearch](#schemadisqualifiedofficersearch)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid query string supplied.|None|
+
+<h4 id="disqualifiedofficersearch-responseschema">Response Schema</h4>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_DisqualifiedOfficerSearchItems">DisqualifiedOfficerSearchItems</h3>
+<!-- backwards compatibility -->
+<a id="schemadisqualifiedofficersearchitems"></a>
+<a id="schema_DisqualifiedOfficerSearchItems"></a>
+<a id="tocSdisqualifiedofficersearchitems"></a>
+<a id="tocsdisqualifiedofficersearchitems"></a>
+
+```json
+{
+  "kind": "searchresults#disqualified-officer",
+  "date_of_birth": "2020-04-08",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "description": "string",
+  "description_identifiers": [
+    0
+  ],
+  "snippet": "string",
+  "matches": [
+    {
+      "title": [
+        0
+      ],
+      "snippet": [
+        0
+      ],
+      "address_snippet": [
+        0
+      ]
+    }
+  ],
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "country": "string",
+      "locality": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "address_snippet": "string",
+  "title": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|true|none|Describes the type of result returned.|
+|date_of_birth|string(date)|false|none|The disqualified officer's date of birth.|
+|links|[[LinksModel](#schemalinksmodel)]|false|none|Links to other resources associated with this search item.|
+|description|string|true|none|The result description.|
+|description_identifiers|[integer]|false|none|An array of enumeration types that make up the search description. See search_descriptions_raw.yaml in api-enumerations.|
+|snippet|string|false|none|Summary information for the result, showing additional details that have matched. In the case of disqualified officers, this would be other disqualification names for the officer, if they exist.|
+|matches|[[MatchesModel](#schemamatchesmodel)]|false|none|A list of members and arrays of character offset, defining substrings that matched the search terms.|
+|address|[[DisqualifiedOfficerAddress](#schemadisqualifiedofficeraddress)]|true|none|The address of the disqualified officer as provided by the disqualifying authority.|
+|address_snippet|string|true|none|A single line address. This will be the address that matched within the indexed document, or the primary address otherwise (as returned by the `address` member).|
+|title|string|true|none|The title of the search result.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|searchresults#disqualified-officer|
+
+<h3 id="tocS_MatchesModel">MatchesModel</h3>
+<!-- backwards compatibility -->
+<a id="schemamatchesmodel"></a>
+<a id="schema_MatchesModel"></a>
+<a id="tocSmatchesmodel"></a>
+<a id="tocsmatchesmodel"></a>
+
+```json
+{
+  "title": [
+    0
+  ],
+  "snippet": [
+    0
+  ],
+  "address_snippet": [
+    0
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|title|[integer]|false|none|An array of character offset into the `title` string. These always occur in pairs, and define the start and end of substrings in the member `title` that matched the search terms. The first character of the string is index 1.|
+|snippet|[integer]|false|none|An array of character offset into the `snippet` string. These always occur in pairs, and define the start and end of substrings in the member `snippet` that matched the search terms. The first character of the string is index 1.|
+|address_snippet|[integer]|false|none|An array of character offset into the `address_snippet` string. These always occur in pairs, and define the start and end of substrings in the member `address_snippet` that matched the search terms.|
+
+<h3 id="tocS_DisqualifiedOfficerSearch">DisqualifiedOfficerSearch</h3>
+<!-- backwards compatibility -->
+<a id="schemadisqualifiedofficersearch"></a>
+<a id="schema_DisqualifiedOfficerSearch"></a>
+<a id="tocSdisqualifiedofficersearch"></a>
+<a id="tocsdisqualifiedofficersearch"></a>
+
+```json
+{
+  "kind": "search#disqualified-officers",
+  "total_results": 0,
+  "start_index": 0,
+  "items_per_page": 0,
+  "items": [
+    {
+      "kind": "searchresults#disqualified-officer",
+      "date_of_birth": "2020-04-08",
+      "links": [
+        {
+          "self": "string"
+        }
+      ],
+      "description": "string",
+      "description_identifiers": [
+        0
+      ],
+      "snippet": "string",
+      "matches": [
+        {
+          "title": [
+            0
+          ],
+          "snippet": [
+            0
+          ],
+          "address_snippet": [
+            0
+          ]
+        }
+      ],
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "country": "string",
+          "locality": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "address_snippet": "string",
+      "title": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|true|none|The type of response returned.|
+|total_results|integer|false|none|The number of further search results available for the current search.|
+|start_index|integer|false|none|The index into the entire result set that this result page starts.|
+|items_per_page|integer|false|none|The number of search items returned per page.|
+|items|[[DisqualifiedOfficerSearchItems](#schemadisqualifiedofficersearchitems)]|false|none|The results of the completed search.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|search#disqualified-officers|
+
+<h3 id="tocS_OfficerAddress">OfficerAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficeraddress"></a>
+<a id="schema_OfficerAddress"></a>
+<a id="tocSofficeraddress"></a>
+<a id="tocsofficeraddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "care_of": "string",
+  "country": "string",
+  "locality": "string",
+  "po_box": "string",
+  "postal_code": "string",
+  "premises": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|false|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|care_of|string|false|none|The care of name.|
+|country|string|false|none|The country. For example, UK.|
+|locality|string|false|none|The locality. For example London.|
+|po_box|string|false|none|The post-office box number.|
+|postal_code|string|false|none|The postal code. For example CF14 3UZ.|
+|premises|string|false|none|The property name or number.|
+|region|string|false|none|The region. For example Surrey.|
+
+<h3 id="tocS_DisqualifiedOfficerAddress">DisqualifiedOfficerAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemadisqualifiedofficeraddress"></a>
+<a id="schema_DisqualifiedOfficerAddress"></a>
+<a id="tocSdisqualifiedofficeraddress"></a>
+<a id="tocsdisqualifiedofficeraddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "country": "string",
+  "locality": "string",
+  "postal_code": "string",
+  "premises": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|false|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|country|string|false|none|The country. For example, UK.|
+|locality|string|false|none|The locality. For example London.|
+|postal_code|string|false|none|The postal code. For example CF14 3UZ.|
+|premises|string|false|none|The property name or number.|
+|region|string|false|none|The region. For example Surrey.|
+
+<h3 id="tocS_OfficerSearchItems">OfficerSearchItems</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficersearchitems"></a>
+<a id="schema_OfficerSearchItems"></a>
+<a id="tocSofficersearchitems"></a>
+<a id="tocsofficersearchitems"></a>
+
+```json
+{
+  "kind": "searchresults#officer",
+  "date_of_birth": [
+    {
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "title": "string",
+  "address_snippet": "string",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "appointment_count": 0,
+  "description": "string",
+  "description_identifiers": [
+    0
+  ],
+  "snippet": "string",
+  "matches": [
+    {
+      "title": [
+        0
+      ],
+      "snippet": [
+        0
+      ],
+      "address_snippet": [
+        0
+      ]
+    }
+  ],
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|true|none|Describes the type of result returned.|
+|date_of_birth|[[OfficerDateOfBirth](#schemaofficerdateofbirth)]|false|none|The officer date of birth details.|
+|title|string|true|none|The title of the search result.|
+|address_snippet|string|true|none|A single line address. This will be the address that matched within the indexed document, or the primary address otherwise (as returned by the `address` member).|
+|links|[[LinksModel](#schemalinksmodel)]|false|none|Links to other resources associated with this search item.|
+|appointment_count|integer|true|none|The total number of appointments the officer has.|
+|description|string|true|none|The result description.|
+|description_identifiers|[integer]|false|none|An array of enumeration types that make up the search description. See search_descriptions_raw.yaml in api-enumerations.|
+|snippet|string|false|none|Summary information for the result, showing additional details that have matched. In the case of company officers, this would be other appointment names for the officer .|
+|matches|[[MatchesModel](#schemamatchesmodel)]|false|none|A list of members and arrays of character offset, defining substrings that matched the search terms.|
+|address|[[OfficerAddress](#schemaofficeraddress)]|true|none|The service address of the officer.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|searchresults#officer|
+
+<h3 id="tocS_CompanySearch">CompanySearch</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanysearch"></a>
+<a id="schema_CompanySearch"></a>
+<a id="tocScompanysearch"></a>
+<a id="tocscompanysearch"></a>
+
+```json
+{
+  "kind": "search#companies",
+  "etag": "string",
+  "items": [
+    {
+      "kind": "searchresult#company",
+      "title": "string",
+      "address_snippet": "string",
+      "links": [
+        {
+          "self": "string"
+        }
+      ],
+      "description": "string",
+      "description_identifier": [
+        0
+      ],
+      "company_number": "string",
+      "external_registration_number": "string",
+      "snippet": "string",
+      "date_of_creation": "2020-04-08",
+      "date_of_cessation": "2020-04-08",
+      "company_type": "private-unlimited",
+      "company_status": "active",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "country": "Wales",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "care_of": "string",
+          "region": "string"
+        }
+      ],
+      "matches": [
+        {
+          "title": [
+            0
+          ],
+          "snippet": [
+            0
+          ],
+          "address_snippet": [
+            0
+          ]
+        }
+      ]
+    }
+  ],
+  "total_results": 0,
+  "start_index": 0,
+  "items_per_page": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|false|none|The type of search response returned.|
+|etag|string|false|none|The ETag of the resource.|
+|items|[[CompanySearchItems](#schemacompanysearchitems)]|false|none|The results of the completed search.|
+|total_results|integer|false|none|The number of further search results available for the current search.|
+|start_index|integer|false|none|The index into the entire result set that this result page starts.|
+|items_per_page|integer|false|none|The number of search items returned per page.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|search#companies|
+
+<h3 id="tocS_OfficerSearch">OfficerSearch</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficersearch"></a>
+<a id="schema_OfficerSearch"></a>
+<a id="tocSofficersearch"></a>
+<a id="tocsofficersearch"></a>
+
+```json
+{
+  "kind": "search#officers",
+  "total_results": 0,
+  "start_index": 0,
+  "items_per_page": 0,
+  "items": [
+    {
+      "kind": "searchresults#officer",
+      "date_of_birth": [
+        {
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "title": "string",
+      "address_snippet": "string",
+      "links": [
+        {
+          "self": "string"
+        }
+      ],
+      "appointment_count": 0,
+      "description": "string",
+      "description_identifiers": [
+        0
+      ],
+      "snippet": "string",
+      "matches": [
+        {
+          "title": [
+            0
+          ],
+          "snippet": [
+            0
+          ],
+          "address_snippet": [
+            0
+          ]
+        }
+      ],
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|true|none|The type of response returned.|
+|total_results|integer|false|none|The number of further search results available for the current search.|
+|start_index|integer|false|none|The index into the entire result set that this result page starts.|
+|items_per_page|integer|false|none|The number of search items returned per page.|
+|items|[[OfficerSearchItems](#schemaofficersearchitems)]|false|none|The results of the completed search.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|search#officers|
+
+<h3 id="tocS_Search">Search</h3>
+<!-- backwards compatibility -->
+<a id="schemasearch"></a>
+<a id="schema_Search"></a>
+<a id="tocSsearch"></a>
+<a id="tocssearch"></a>
+
+```json
+{
+  "kind": "search#all",
+  "etag": "string",
+  "items": [
+    {
+      "kind": "searchresult#company",
+      "title": "string",
+      "address_snippet": "string",
+      "links": [
+        {
+          "self": "string"
+        }
+      ],
+      "description": "string",
+      "description_identifier": [
+        0
+      ],
+      "snippet": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "country": "Wales",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "care_of": "string",
+          "region": "string"
+        }
+      ],
+      "matches": [
+        {
+          "title": [
+            0
+          ],
+          "snippet": [
+            0
+          ],
+          "address_snippet": [
+            0
+          ]
+        }
+      ]
+    }
+  ],
+  "total_results": 0,
+  "start_index": 0,
+  "items_per_page": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|false|none|The type of search response returned.|
+|etag|string|false|none|The ETag of the resource.|
+|items|[[SearchItems](#schemasearchitems)]|false|none|The results of the completed search. See `items.kind` for details of each specific result resource returned.|
+|total_results|integer|false|none|The number of further search results available for the current search.|
+|start_index|integer|false|none|The index into the entire result set that this result page starts.|
+|items_per_page|integer|false|none|The number of search items returned per page.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|search#all|
+
+<h3 id="tocS_CompanySearchItems">CompanySearchItems</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanysearchitems"></a>
+<a id="schema_CompanySearchItems"></a>
+<a id="tocScompanysearchitems"></a>
+<a id="tocscompanysearchitems"></a>
+
+```json
+{
+  "kind": "searchresult#company",
+  "title": "string",
+  "address_snippet": "string",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "description": "string",
+  "description_identifier": [
+    0
+  ],
+  "company_number": "string",
+  "external_registration_number": "string",
+  "snippet": "string",
+  "date_of_creation": "2020-04-08",
+  "date_of_cessation": "2020-04-08",
+  "company_type": "private-unlimited",
+  "company_status": "active",
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "country": "Wales",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "care_of": "string",
+      "region": "string"
+    }
+  ],
+  "matches": [
+    {
+      "title": [
+        0
+      ],
+      "snippet": [
+        0
+      ],
+      "address_snippet": [
+        0
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|false|none|The type of search result.|
+|title|string|false|none|The title of the search result.|
+|address_snippet|string|false|none|A single line address. This will be the address that matched within the indexed document, or the primary address otherwise (as returned by the `address` member).|
+|links|[[LinksModel](#schemalinksmodel)]|false|none|The URL of the search result.|
+|description|string|false|none|The result description.|
+|description_identifier|[integer]|false|none|An array of enumeration types that make up the search description. See search_descriptions_raw.yaml in api-enumerations|
+|company_number|string|false|none|The company registration / incorporation number of the company.|
+|external_registration_number|string|false|none|The number given by an external registration body.|
+|snippet|string|false|none|Summary information for the result, showing additional details that have matched. In the case of companies, this would be previous company names.|
+|date_of_creation|string(date)|false|none|The date the company was created.|
+|date_of_cessation|string(date)|false|none|The date the company ended.|
+|company_type|string|false|none|The company type.|
+|company_status|string|false|none|The company status.|
+|address|[[registeredOfficeAddress](#schemaregisteredofficeaddress)]|false|none|The address of the company's registered office.|
+|matches|[[MatchesModel](#schemamatchesmodel)]|false|none|A list of members and arrays of character offset, defining substrings that matched the search terms.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|searchresult#company|
+|company_type|private-unlimited|
+|company_type|ltd|
+|company_type|plc|
+|company_type|old-public-company|
+|company_type|private-limited-guarant-nsc-limited-exemption|
+|company_type|limited-partnership|
+|company_type|private-limited-guarant-nsc|
+|company_type|converted-or-closed|
+|company_type|private-unlimited-nsc|
+|company_type|private-limited-shares-section-30-exemption|
+|company_type|protected-cell-company|
+|company_type|assurance-company|
+|company_type|oversea-company|
+|company_type|eeig|
+|company_type|icvc-securities|
+|company_type|icvc-warrant|
+|company_type|icvc-umbrella|
+|company_type|industrial-and-provident-society|
+|company_type|northern-ireland|
+|company_type|northern-ireland-other|
+|company_type|llp|
+|company_type|royal-charter|
+|company_type|investment-company-with-variable-capital|
+|company_type|unregistered-company|
+|company_type|other|
+|company_type|european-public-limited-liability-company-se|
+|company_type|scottish-partnership|
+|company_type|charitable-incorporated-organisation|
+|company_type|scottish-charitable-incorporated-organisation|
+|company_type|further-education-or-sixth-form-college-corporation|
+|company_status|active|
+|company_status|dissolved|
+|company_status|liquidation|
+|company_status|receivership|
+|company_status|administration|
+|company_status|voluntary-arrangement|
+|company_status|converted-closed|
+|company_status|insolvency-proceedings|
+
+<h3 id="tocS_SearchItems">SearchItems</h3>
+<!-- backwards compatibility -->
+<a id="schemasearchitems"></a>
+<a id="schema_SearchItems"></a>
+<a id="tocSsearchitems"></a>
+<a id="tocssearchitems"></a>
+
+```json
+{
+  "kind": "searchresult#company",
+  "title": "string",
+  "address_snippet": "string",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "description": "string",
+  "description_identifier": [
+    0
+  ],
+  "snippet": "string",
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "country": "Wales",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "care_of": "string",
+      "region": "string"
+    }
+  ],
+  "matches": [
+    {
+      "title": [
+        0
+      ],
+      "snippet": [
+        0
+      ],
+      "address_snippet": [
+        0
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|kind|string|false|none|The type of search result. Refer to the full resource descriptions [api/docs/company/company_number/CompanySearch-resource.html](api/docs/company/company_number/CompanySearch-resource.html)CompanySearch resource, [api/docs/company/company_number/OfficerSearch-resource.html](api/docs/company/company_number/OfficerSearch-resource.html)OfficerSearch resource and [api/docs/company/company_number/DisqualifiedOfficerSearch-resource.html](api/docs/company/company_number/DisqualifiedOfficerSearch-resource.html)DisqualifiedOfficerSearch resource for the full list of members returned.|
+|title|string|false|none|The title of the search result.|
+|address_snippet|string|false|none|A single line address. This will be the address that matched within the indexed document, or the primary address otherwise (as returned by the `address` member).|
+|links|[[LinksModel](#schemalinksmodel)]|false|none|The URL of the search result.|
+|description|string|false|none|The result description.|
+|description_identifier|[integer]|false|none|An array of enumeration types that make up the search description. See search_descriptions_raw.yaml in api-enumerations|
+|snippet|string|false|none|Summary information for the result, showing additional details that have matched. In the case of companies, this would be previous company names.|
+|address|[[registeredOfficeAddress](#schemaregisteredofficeaddress)]|false|none|The address of the company's registered office.|
+|matches|[[MatchesModel](#schemamatchesmodel)]|false|none|A list of members and arrays of character offset, defining substrings that matched the search terms.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|searchresult#company|
+|kind|searchresults#officer|
+|kind|searchresults#disqualified-officer|
+
+<h3 id="tocS_OfficerDateOfBirth">OfficerDateOfBirth</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficerdateofbirth"></a>
+<a id="schema_OfficerDateOfBirth"></a>
+<a id="tocSofficerdateofbirth"></a>
+<a id="tocsofficerdateofbirth"></a>
+
+```json
+{
+  "month": 0,
+  "year": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|month|integer|true|none|The month the officer was born in.|
+|year|integer|true|none|The year the officer was born in.|
+
+<h3 id="tocS_LinksModel">LinksModel</h3>
+<!-- backwards compatibility -->
+<a id="schemalinksmodel"></a>
+<a id="schema_LinksModel"></a>
+<a id="tocSlinksmodel"></a>
+<a id="tocslinksmodel"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|false|none|The URL of the resource being returned by the search item.|
+
+<h3 id="tocS_registeredOfficeAddress">registeredOfficeAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemaregisteredofficeaddress"></a>
+<a id="schema_registeredOfficeAddress"></a>
+<a id="tocSregisteredofficeaddress"></a>
+<a id="tocsregisteredofficeaddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "country": "Wales",
+  "locality": "string",
+  "po_box": "string",
+  "postal_code": "string",
+  "care_of": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|false|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|country|string|false|none|The country.|
+|locality|string|false|none|The locality e.g London.|
+|po_box|string|false|none|The post-office box number.|
+|postal_code|string|false|none|The postal code e.g CF14 3UZ.|
+|care_of|string|false|none|The care of name.|
+|region|string|false|none|The region e.g Surrey.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|country|Wales|
+|country|England|
+|country|Scotland|
+|country|Great Britain|
+|country|Not specified|
+|country|United Kingdom|
+|country|Northern Ireland|
+

--- a/openapi3render/markdown_specs/insolvency.html.md
+++ b/openapi3render/markdown_specs/insolvency.html.md
@@ -1,0 +1,623 @@
+---
+title: insolvency Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="insolvency-specification">insolvency Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="insolvency-specification-company-company_number-insolvency">company{company_number}insolvency</h2>
+
+## readCompanyInsolvency
+
+<a id="opIdreadCompanyInsolvency"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/insolvency \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/insolvency HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/insolvency',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/insolvency',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/insolvency', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/insolvency', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/insolvency");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/insolvency", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/insolvency`
+
+*Get company insolvency information*
+
+<h4 id="readcompanyinsolvency-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the basic information to return.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "cases": [
+    {
+      "type": "compulsory-liquidation",
+      "dates": [
+        {
+          "type": "instrumented-on",
+          "date": "2020-04-08"
+        }
+      ],
+      "notes": [
+        "string"
+      ],
+      "practitioners": [
+        {
+          "name": "string",
+          "address": [
+            {
+              "address_line_1": "string",
+              "address_line_2": "string",
+              "locality": "string",
+              "region": "string",
+              "postal_code": "string",
+              "country": "string"
+            }
+          ],
+          "appointed_on": "2020-04-08",
+          "ceased_to_act_on": "2020-04-08",
+          "role": "final-liquidator"
+        }
+      ],
+      "links": [
+        {
+          "charge": "string"
+        }
+      ],
+      "number": 0
+    }
+  ],
+  "status": [
+    {}
+  ]
+}
+```
+
+<h4 id="readcompanyinsolvency-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[companyInsolvency](#schemacompanyinsolvency)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Resource not found|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_companyInsolvency">companyInsolvency</h3>
+<!-- backwards compatibility -->
+<a id="schemacompanyinsolvency"></a>
+<a id="schema_companyInsolvency"></a>
+<a id="tocScompanyinsolvency"></a>
+<a id="tocscompanyinsolvency"></a>
+
+```json
+{
+  "etag": "string",
+  "cases": [
+    {
+      "type": "compulsory-liquidation",
+      "dates": [
+        {
+          "type": "instrumented-on",
+          "date": "2020-04-08"
+        }
+      ],
+      "notes": [
+        "string"
+      ],
+      "practitioners": [
+        {
+          "name": "string",
+          "address": [
+            {
+              "address_line_1": "string",
+              "address_line_2": "string",
+              "locality": "string",
+              "region": "string",
+              "postal_code": "string",
+              "country": "string"
+            }
+          ],
+          "appointed_on": "2020-04-08",
+          "ceased_to_act_on": "2020-04-08",
+          "role": "final-liquidator"
+        }
+      ],
+      "links": [
+        {
+          "charge": "string"
+        }
+      ],
+      "number": 0
+    }
+  ],
+  "status": [
+    {}
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|cases|[[case](#schemacase)]|true|none|List of insolvency cases.|
+|status|[object]|true|none|Company insolvency status details|
+
+<h3 id="tocS_practitioners">practitioners</h3>
+<!-- backwards compatibility -->
+<a id="schemapractitioners"></a>
+<a id="schema_practitioners"></a>
+<a id="tocSpractitioners"></a>
+<a id="tocspractitioners"></a>
+
+```json
+{
+  "name": "string",
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "locality": "string",
+      "region": "string",
+      "postal_code": "string",
+      "country": "string"
+    }
+  ],
+  "appointed_on": "2020-04-08",
+  "ceased_to_act_on": "2020-04-08",
+  "role": "final-liquidator"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|true|none|The name of the practitioner.|
+|address|[[practitionerAddress](#schemapractitioneraddress)]|true|none|The practitioners' address.|
+|appointed_on|string(date)|false|none|The date the practitioner was appointed on.|
+|ceased_to_act_on|string(date)|false|none|The date the practitioner ceased to act for the case.|
+|role|string|false|none|The type of role.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|role|final-liquidator|
+|role|receiver|
+|role|receiver-manager|
+|role|proposed-liquidator|
+|role|provisional-liquidator|
+|role|administrative-receiver|
+|role|practitioner|
+|role|interim-liquidator|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_links">links</h3>
+<!-- backwards compatibility -->
+<a id="schemalinks"></a>
+<a id="schema_links"></a>
+<a id="tocSlinks"></a>
+<a id="tocslinks"></a>
+
+```json
+{
+  "charge": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|charge|string|false|none|The link to the charge this case is lodged against.|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_case">case</h3>
+<!-- backwards compatibility -->
+<a id="schemacase"></a>
+<a id="schema_case"></a>
+<a id="tocScase"></a>
+<a id="tocscase"></a>
+
+```json
+{
+  "type": "compulsory-liquidation",
+  "dates": [
+    {
+      "type": "instrumented-on",
+      "date": "2020-04-08"
+    }
+  ],
+  "notes": [
+    "string"
+  ],
+  "practitioners": [
+    {
+      "name": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "locality": "string",
+          "region": "string",
+          "postal_code": "string",
+          "country": "string"
+        }
+      ],
+      "appointed_on": "2020-04-08",
+      "ceased_to_act_on": "2020-04-08",
+      "role": "final-liquidator"
+    }
+  ],
+  "links": [
+    {
+      "charge": "string"
+    }
+  ],
+  "number": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|The type of case. For enumeration descriptions see `insolvency_case_type` section in the enumeration mappings.|
+|dates|[[caseDates](#schemacasedates)]|true|none|The dates specific to the case.|
+|notes|[string]|false|none|Notes that apply to the case.|
+|practitioners|[[practitioners](#schemapractitioners)]|true|none|The practitioners for the case.|
+|links|[[links](#schemalinks)]|false|none|The resources related to this case|
+|number|integer|false|none|The case number.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|compulsory-liquidation|
+|type|creditors-voluntary-liquidation|
+|type|members-voluntary-liquidation|
+|type|in-administration|
+|type|corporate-voluntary-arrangement|
+|type|corporate-voluntary-arrangement-moratorium|
+|type|administration-order|
+|type|receiver-manager|
+|type|administrative-receiver|
+|type|receivership|
+|type|foreign-insolvency|
+
+<h3 id="tocS_caseDates">caseDates</h3>
+<!-- backwards compatibility -->
+<a id="schemacasedates"></a>
+<a id="schema_caseDates"></a>
+<a id="tocScasedates"></a>
+<a id="tocscasedates"></a>
+
+```json
+{
+  "type": "instrumented-on",
+  "date": "2020-04-08"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Describes what date is represented by the associated `date` element.  For enumeration descriptions see `insolvency_case_date_type` section in the enumeration mappings.|
+|date|string(date)|true|none|The case date, described by `date_type`.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|instrumented-on|
+|type|administration-started-on|
+|type|administration-discharged-on|
+|type|administration-ended-on|
+|type|concluded-winding-up-on|
+|type|petitioned-on|
+|type|ordered-to-wind-up-on|
+|type|due-to-be-dissolved-on|
+|type|case-end-on|
+|type|wound-up-on|
+|type|voluntary-arrangement-started-on|
+|type|voluntary-arrangement-ended-on|
+|type|moratorium-started-on|
+|type|moratorium-ended-on|
+|type|declaration-solvent-on|
+
+<h3 id="tocS_practitionerAddress">practitionerAddress</h3>
+<!-- backwards compatibility -->
+<a id="schemapractitioneraddress"></a>
+<a id="schema_practitionerAddress"></a>
+<a id="tocSpractitioneraddress"></a>
+<a id="tocspractitioneraddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "locality": "string",
+  "region": "string",
+  "postal_code": "string",
+  "country": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|true|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|locality|string|false|none|The locality. For example London.|
+|region|string|false|none|The region. For example Surrey.|
+|postal_code|string|true|none|The postal code. For example CF14 3UZ.|
+|country|string|false|none|The country.|
+

--- a/openapi3render/markdown_specs/officerAppointmentList.html.md
+++ b/openapi3render/markdown_specs/officerAppointmentList.html.md
@@ -1,0 +1,823 @@
+---
+title: officerAppointmentList Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="officerappointmentlist-specification">officerAppointmentList Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="officerappointmentlist-specification-officers-officer_id-appointments">officers{officer_id}appointments</h2>
+
+## appointmentList
+
+<a id="opIdappointmentList"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/officers/{officer_id}/appointments \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/officers/{officer_id}/appointments HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/officers/{officer_id}/appointments',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/officers/{officer_id}/appointments',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/officers/{officer_id}/appointments', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/officers/{officer_id}/appointments', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/officers/{officer_id}/appointments");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/officers/{officer_id}/appointments", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /officers/{officer_id}/appointments`
+
+*List the officer appointments*
+
+<h4 id="appointmentlist-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|officer_id|path|string|true|The officer id of the appointment list being requested.|
+|items_per_page|query|integer|false|The number of appointments to return per page.|
+|start_index|query|integer|false|The first row of data to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the items_per_page parameter.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "date_of_birth": [
+    {
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "etag": "string",
+  "is_corporate_officer": true,
+  "items": [
+    {
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "appointed_before": "2020-04-08",
+      "appointed_on": "2020-04-08",
+      "appointed_to": [
+        {
+          "company_name": "string",
+          "company_number": "string",
+          "company_status": "string"
+        }
+      ],
+      "name": "string",
+      "country_of_residence": "string",
+      "former_names": [
+        {
+          "forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "identification": [
+        {
+          "identification_type": "eea",
+          "legal_authority": "string",
+          "legal_form": "string",
+          "place_registered": "string",
+          "registration_number": "string"
+        }
+      ],
+      "is_pre_1992_appointment": true,
+      "links": [
+        {
+          "company": "string"
+        }
+      ],
+      "name_elements": [
+        {
+          "forename": "string",
+          "title": "string",
+          "other_forenames": "string",
+          "surname": "string",
+          "honours": "string"
+        }
+      ],
+      "nationality": "string",
+      "occupation": "string",
+      "officer_role": "cic-manager",
+      "resigned_on": "2020-04-08"
+    }
+  ],
+  "items_per_page": 0,
+  "kind": "personal-appointment",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "name": "string",
+  "start_index": 0,
+  "total_results": 0
+}
+```
+
+<h4 id="appointmentlist-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[appointmentList](#schemaappointmentlist)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_address">address</h3>
+<!-- backwards compatibility -->
+<a id="schemaaddress"></a>
+<a id="schema_address"></a>
+<a id="tocSaddress"></a>
+<a id="tocsaddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "care_of": "string",
+  "country": "string",
+  "locality": "string",
+  "po_box": "string",
+  "postal_code": "string",
+  "premises": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|false|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|care_of|string|false|none|The care of name.|
+|country|string|false|none|The country. For example, UK.|
+|locality|string|false|none|The locality. For example London.|
+|po_box|string|false|none|The post-office box number.|
+|postal_code|string|false|none|The postal code. For example CF14 3UZ.|
+|premises|string|false|none|The property name or number.|
+|region|string|false|none|The region. For example Surrey.|
+
+<h3 id="tocS_appointmentLinkTypes">appointmentLinkTypes</h3>
+<!-- backwards compatibility -->
+<a id="schemaappointmentlinktypes"></a>
+<a id="schema_appointmentLinkTypes"></a>
+<a id="tocSappointmentlinktypes"></a>
+<a id="tocsappointmentlinktypes"></a>
+
+```json
+{
+  "company": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|company|string|true|none|Link to the company profile resource that this appointment is associated with.|
+
+<h3 id="tocS_appointmentList">appointmentList</h3>
+<!-- backwards compatibility -->
+<a id="schemaappointmentlist"></a>
+<a id="schema_appointmentList"></a>
+<a id="tocSappointmentlist"></a>
+<a id="tocsappointmentlist"></a>
+
+```json
+{
+  "date_of_birth": [
+    {
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "etag": "string",
+  "is_corporate_officer": true,
+  "items": [
+    {
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "appointed_before": "2020-04-08",
+      "appointed_on": "2020-04-08",
+      "appointed_to": [
+        {
+          "company_name": "string",
+          "company_number": "string",
+          "company_status": "string"
+        }
+      ],
+      "name": "string",
+      "country_of_residence": "string",
+      "former_names": [
+        {
+          "forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "identification": [
+        {
+          "identification_type": "eea",
+          "legal_authority": "string",
+          "legal_form": "string",
+          "place_registered": "string",
+          "registration_number": "string"
+        }
+      ],
+      "is_pre_1992_appointment": true,
+      "links": [
+        {
+          "company": "string"
+        }
+      ],
+      "name_elements": [
+        {
+          "forename": "string",
+          "title": "string",
+          "other_forenames": "string",
+          "surname": "string",
+          "honours": "string"
+        }
+      ],
+      "nationality": "string",
+      "occupation": "string",
+      "officer_role": "cic-manager",
+      "resigned_on": "2020-04-08"
+    }
+  ],
+  "items_per_page": 0,
+  "kind": "personal-appointment",
+  "links": [
+    {
+      "self": "string"
+    }
+  ],
+  "name": "string",
+  "start_index": 0,
+  "total_results": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|date_of_birth|[[dateOfBirth](#schemadateofbirth)]|false|none|The officer's date of birth details.|
+|etag|string|true|none|The ETag of the resource.|
+|is_corporate_officer|boolean|true|none|Indicator representing if the officer is a corporate body.|
+|items|[[officerAppointmentSummary](#schemaofficerappointmentsummary)]|true|none|The list of officer appointments.|
+|items_per_page|integer|true|none|The number of officer appointments to return per page.|
+|kind|string|true|none|none|
+|links|[[officerLinkTypes](#schemaofficerlinktypes)]|true|none|Links to other resources associated with this officer appointment resource.|
+|name|string|true|none|The corporate or natural officer name.|
+|start_index|integer|true|none|The first row of data to retrieve, starting at 0. Use this parameter as a pagination mechanism along with the `items_per_page` parameter.|
+|total_results|integer|true|none|The total number of officer appointments in this result set.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|personal-appointment|
+
+<h3 id="tocS_corporateIdent">corporateIdent</h3>
+<!-- backwards compatibility -->
+<a id="schemacorporateident"></a>
+<a id="schema_corporateIdent"></a>
+<a id="tocScorporateident"></a>
+<a id="tocscorporateident"></a>
+
+```json
+{
+  "identification_type": "eea",
+  "legal_authority": "string",
+  "legal_form": "string",
+  "place_registered": "string",
+  "registration_number": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|identification_type|string|false|none|none|
+|legal_authority|string|false|none|The legal authority supervising the company.|
+|legal_form|string|false|none|The legal form of the company as defined by its country of registration.|
+|place_registered|string|false|none|Place registered.|
+|registration_number|string|false|none|Company registration number.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|identification_type|eea|
+|identification_type|non-eea|
+
+<h3 id="tocS_appointedTo">appointedTo</h3>
+<!-- backwards compatibility -->
+<a id="schemaappointedto"></a>
+<a id="schema_appointedTo"></a>
+<a id="tocSappointedto"></a>
+<a id="tocsappointedto"></a>
+
+```json
+{
+  "company_name": "string",
+  "company_number": "string",
+  "company_status": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|company_name|string|false|none|The name of the company the officer is acting for.|
+|company_number|string|true|none|The number of the company the officer is acting for.|
+|company_status|string|false|none|The status of the company the officer is acting for.|
+
+<h3 id="tocS_dateOfBirth">dateOfBirth</h3>
+<!-- backwards compatibility -->
+<a id="schemadateofbirth"></a>
+<a id="schema_dateOfBirth"></a>
+<a id="tocSdateofbirth"></a>
+<a id="tocsdateofbirth"></a>
+
+```json
+{
+  "month": 0,
+  "year": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|month|integer|true|none|The month the officer was born in.|
+|year|integer|true|none|The year the officer was born in.|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_formerNames">formerNames</h3>
+<!-- backwards compatibility -->
+<a id="schemaformernames"></a>
+<a id="schema_formerNames"></a>
+<a id="tocSformernames"></a>
+<a id="tocsformernames"></a>
+
+```json
+{
+  "forenames": "string",
+  "surname": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|forenames|string|false|none|Former forenames of the officer.|
+|surname|string|false|none|Former surnames of the officer.|
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_officerAppointmentSummary">officerAppointmentSummary</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficerappointmentsummary"></a>
+<a id="schema_officerAppointmentSummary"></a>
+<a id="tocSofficerappointmentsummary"></a>
+<a id="tocsofficerappointmentsummary"></a>
+
+```json
+{
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "appointed_before": "2020-04-08",
+  "appointed_on": "2020-04-08",
+  "appointed_to": [
+    {
+      "company_name": "string",
+      "company_number": "string",
+      "company_status": "string"
+    }
+  ],
+  "name": "string",
+  "country_of_residence": "string",
+  "former_names": [
+    {
+      "forenames": "string",
+      "surname": "string"
+    }
+  ],
+  "identification": [
+    {
+      "identification_type": "eea",
+      "legal_authority": "string",
+      "legal_form": "string",
+      "place_registered": "string",
+      "registration_number": "string"
+    }
+  ],
+  "is_pre_1992_appointment": true,
+  "links": [
+    {
+      "company": "string"
+    }
+  ],
+  "name_elements": [
+    {
+      "forename": "string",
+      "title": "string",
+      "other_forenames": "string",
+      "surname": "string",
+      "honours": "string"
+    }
+  ],
+  "nationality": "string",
+  "occupation": "string",
+  "officer_role": "cic-manager",
+  "resigned_on": "2020-04-08"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address|[[address](#schemaaddress)]|true|none|The correspondence address of the officer.|
+|appointed_before|string(date)|false|none|The date the officer was appointed before. Only present when the `is_pre_1992_appointment` attribute is `true`.|
+|appointed_on|string(date)|false|none|The date the officer was appointed.|
+|appointed_to|[[appointedTo](#schemaappointedto)]|true|none|The company information of the appointment.|
+|name|string|true|none|The full name of the officer.|
+|country_of_residence|string|false|none|The officer's country of residence.|
+|former_names|[[formerNames](#schemaformernames)]|false|none|Former names for the officer, if there are any.|
+|identification|[[corporateIdent](#schemacorporateident)]|false|none|Only one from `eea` or `non-eea` can be supplied, not both.|
+|is_pre_1992_appointment|boolean|false|none|Indicator representing if the officer was appointed before their appointment date.|
+|links|[[appointmentLinkTypes](#schemaappointmentlinktypes)]|true|none|Links to other resources associated with this officer appointment item.|
+|name_elements|[[nameElements](#schemanameelements)]|false|none|A document encapsulating the separate elements of a natural officer's name.|
+|nationality|string|false|none|The officer's nationality.|
+|occupation|string|false|none|The officer's occupation.|
+|officer_role|string|true|none|none|
+|resigned_on|string(date)|false|none|The date the officer was resigned.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|officer_role|cic-manager|
+|officer_role|corporate-director|
+|officer_role|corporate-llp-designated-member|
+|officer_role|corporate-llp-member|
+|officer_role|corporate-member-of-a-management|
+|officer_role|corporate-member-of-a-supervisory-organ|
+|officer_role|corporate-member-of-an-administrative-organ|
+|officer_role|corporate-nominee-director|
+|officer_role|corporate-nominee-secretary|
+|officer_role|corporate-secretary|
+|officer_role|director|
+|officer_role|judicial-factor|
+|officer_role|llp-designated-member|
+|officer_role|llp-member|
+|officer_role|member-of-a-management|
+|officer_role|member-of-a-supervisory-organ|
+|officer_role|member-of-an-administrative-organ|
+|officer_role|nominee-director|
+|officer_role|nominee-secretary|
+|officer_role|receiver-and-manager|
+|officer_role|secretary|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_officerLinkTypes">officerLinkTypes</h3>
+<!-- backwards compatibility -->
+<a id="schemaofficerlinktypes"></a>
+<a id="schema_officerLinkTypes"></a>
+<a id="tocSofficerlinktypes"></a>
+<a id="tocsofficerlinktypes"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|Link to this officer appointment resource.|
+
+<h3 id="tocS_nameElements">nameElements</h3>
+<!-- backwards compatibility -->
+<a id="schemanameelements"></a>
+<a id="schema_nameElements"></a>
+<a id="tocSnameelements"></a>
+<a id="tocsnameelements"></a>
+
+```json
+{
+  "forename": "string",
+  "title": "string",
+  "other_forenames": "string",
+  "surname": "string",
+  "honours": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|forename|string|false|none|The forename of the officer.|
+|title|string|false|none|Title of the officer.|
+|other_forenames|string|false|none|Other forenames of the officer.|
+|surname|string|true|none|The surname of the officer.|
+|honours|string|false|none|Honours an officer might have.|
+

--- a/openapi3render/markdown_specs/psc.html.md
+++ b/openapi3render/markdown_specs/psc.html.md
@@ -1,0 +1,2648 @@
+---
+title: psc Specification v0.0.1
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="psc-specification">psc Specification v0.0.1</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+**This specification was generated from old data and may not reflect the actual API.**
+
+Base URLs:
+
+* <a href="http://example.com/api_url">http://example.com/api_url</a>
+
+<h2 id="psc-specification-company-company_number-persons-with-significant-control">company{company_number}persons-with-significant-control</h2>
+
+## getCorporateEntityWithSignificantControl
+
+<a id="opIdgetCorporateEntityWithSignificantControl"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}`
+
+*Get the corporate entity with significant control*
+
+<h4 id="getcorporateentitywithsignificantcontrol-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the corporate entity with significant control details being requested.|
+|psc_id|path|string|true|The id of the corporate entity with significant control details being requested.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "kind": "corporate-entity-person-with-significant-control",
+  "name": "string",
+  "links": [
+    {
+      "self": "string",
+      "statement": "string"
+    }
+  ],
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "identification": [
+    {
+      "legal_authority": "string",
+      "legal_form": "string",
+      "place_registered": "string",
+      "registration_number": "string",
+      "country_registered": "string"
+    }
+  ],
+  "natures_of_control": [
+    "ownership-of-shares-25-to-50-percent"
+  ]
+}
+```
+
+<h4 id="getcorporateentitywithsignificantcontrol-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[corporateEntity](#schemacorporateentity)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## listPersonsWithSignificantControl
+
+<a id="opIdlistPersonsWithSignificantControl"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/persons-with-significant-control \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/persons-with-significant-control HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/persons-with-significant-control',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/persons-with-significant-control',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/persons-with-significant-control', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/persons-with-significant-control', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/persons-with-significant-control");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/persons-with-significant-control", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/persons-with-significant-control`
+
+*List the company persons with significant control*
+
+<h4 id="listpersonswithsignificantcontrol-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the persons with significant control list being requested.|
+|items_per_page|query|integer|false|The number of persons with significant control to return per page.|
+|start_index|query|integer|false|The offset into the entire result set that this page starts.|
+|register_view|query|string|false|Display register specific information. If register is held at Companies House and register_view is set to true, only PSCs which are active or were terminated during election period are shown together with full dates of birth where available. Accepted values are: <ul><li><code>true</code></li><li><code>false</code></li></ul>Defaults to false|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "items_per_page": 0,
+  "kind": "persons-with-significant-control#list",
+  "items": [
+    {
+      "etag": "string",
+      "notified_on": "2020-04-08",
+      "ceased_on": "2020-04-08",
+      "country_of_residence": "string",
+      "date_of_birth": [
+        {
+          "day": 0,
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "name": "string",
+      "name_elements": [
+        {
+          "forename": "string",
+          "title": "string",
+          "other_forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "links": [
+        {
+          "self": "string",
+          "statement": "string"
+        }
+      ],
+      "nationality": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "natures_of_control": [
+        "ownership-of-shares-25-to-50-percent"
+      ]
+    }
+  ],
+  "start_index": 0,
+  "total_results": 0,
+  "active_count": 0,
+  "ceased_count": 0,
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control_statements_list": "string"
+    }
+  ]
+}
+```
+
+<h4 id="listpersonswithsignificantcontrol-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[list](#schemalist)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## getLegalPersonWithSignificantControl
+
+<a id="opIdgetLegalPersonWithSignificantControl"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/persons-with-significant-control/legal-person/{psc_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/persons-with-significant-control/legal-person/{psc_id}`
+
+*Get the legal person with significant control*
+
+<h4 id="getlegalpersonwithsignificantcontrol-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the legal person with significant control details being requested.|
+|psc_id|path|string|true|The id of the legal person with significant control details being requested.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "kind": "legal-person-with-significant-control",
+  "name": "string",
+  "links": [
+    {
+      "self": "string",
+      "statement": "string"
+    }
+  ],
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "identification": [
+    {
+      "legal_authority": "string",
+      "legal_form": "string"
+    }
+  ],
+  "natures_of_control": [
+    "ownership-of-shares-25-to-50-percent"
+  ]
+}
+```
+
+<h4 id="getlegalpersonwithsignificantcontrol-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[legalPerson](#schemalegalperson)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## getIndividualWithSignificantControl
+
+<a id="opIdgetIndividualWithSignificantControl"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/persons-with-significant-control/individual/{psc_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/persons-with-significant-control/individual/{psc_id}`
+
+*Get the individual person with significant control*
+
+<h4 id="getindividualwithsignificantcontrol-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the person with significant control details being requested.|
+|psc_id|path|string|true|The id of the person with significant control details being requested.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "kind": "individual-person-with-significant-control",
+  "country_of_residence": "string",
+  "date_of_birth": [
+    {
+      "day": 0,
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "name": "string",
+  "name_elements": [
+    {
+      "forename": "string",
+      "title": "string",
+      "other_forenames": "string",
+      "surname": "string"
+    }
+  ],
+  "links": [
+    {
+      "self": "string",
+      "statement": "string"
+    }
+  ],
+  "nationality": "string",
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "natures_of_control": [
+    "ownership-of-shares-25-to-50-percent"
+  ]
+}
+```
+
+<h4 id="getindividualwithsignificantcontrol-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[individual](#schemaindividual)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## getSuperSecurePersonWithSignificantControl
+
+<a id="opIdgetSuperSecurePersonWithSignificantControl"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/persons-with-significant-control/super-secure/{super_secure_id}`
+
+*Get the super secure person with significant control*
+
+<h4 id="getsupersecurepersonwithsignificantcontrol-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the super secure person with significant control details being requested.|
+|super_secure_id|path|string|true|The id of the super secure person with significant control details being requested.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "kind": "super-secure-person-with-significant-control",
+  "description": "super-secure-persons-with-significant-control",
+  "ceased": true,
+  "links": [
+    {
+      "self": "string"
+    }
+  ]
+}
+```
+
+<h4 id="getsupersecurepersonwithsignificantcontrol-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[superSecure](#schemasupersecure)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## listPersonsWithSignificantControlStatements
+
+<a id="opIdlistPersonsWithSignificantControlStatements"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/persons-with-significant-control-statements`
+
+*List the company persons with significant control statements*
+
+<h4 id="listpersonswithsignificantcontrolstatements-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the persons with significant control statements list being requested.|
+|items_per_page|query|integer|false|The number of persons with significant control statements to return per page.|
+|start_index|query|integer|false|The offset into the entire result set that this page starts.|
+|register_view|query|string|false|Display register specific information. If register is held at Companies House and register_view is set to true, only statements which are active or were withdrawn during election period are shown. Accepted values are: <ul><li><code>true</code></li><li><code>false</code></li></ul>Defaults to false|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "items_per_page": 0,
+  "kind": "persons-with-significant-control#statements-list",
+  "items": [
+    {
+      "etag": "string",
+      "kind": "person-with-significant-control-statement",
+      "notified_on": "2020-04-08",
+      "ceased_on": "2020-04-08",
+      "restrictions_notice_withdrawal_reason": "restrictions-notice-withdrawn-by-court-order",
+      "statement": "no-individual-or-entity-with-signficant-control",
+      "linked_psc_name": "string",
+      "links": [
+        {
+          "self": "string",
+          "person_with_significant_control": "string"
+        }
+      ]
+    }
+  ],
+  "start_index": 0,
+  "total_results": 0,
+  "active_count": 0,
+  "ceased_count": 0,
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control_list": "string"
+    }
+  ]
+}
+```
+
+<h4 id="listpersonswithsignificantcontrolstatements-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[statementList](#schemastatementlist)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## getPersonsWithSignificantControlStatement
+
+<a id="opIdgetPersonsWithSignificantControlStatement"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id} HTTP/1.1
+Host: example.com
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+
+};
+
+fetch('http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id}', headers = headers)
+
+print r.json()
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+    
+    );
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+        
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://example.com/api_url/company/{company_number}/persons-with-significant-control-statements/{statement_id}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /company/{company_number}/persons-with-significant-control-statements/{statement_id}`
+
+*Get the person with significant control statement*
+
+<h4 id="getpersonswithsignificantcontrolstatement-parameters">Parameters</h4>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|company_number|path|string|true|The company number of the person with significant control statement details being requested.|
+|statement_id|path|string|true|The id of the person with significant control statement details being requested.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "etag": "string",
+  "kind": "person-with-significant-control-statement",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "restrictions_notice_withdrawal_reason": "restrictions-notice-withdrawn-by-court-order",
+  "statement": "no-individual-or-entity-with-signficant-control",
+  "linked_psc_name": "string",
+  "links": [
+    {
+      "self": "string",
+      "person_with_significant_control": "string"
+    }
+  ]
+}
+```
+
+<h4 id="getpersonswithsignificantcontrolstatement-responses">Responses</h4>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|success|[statement](#schemastatement)|
+|400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Bad request|[error](#schemaerror)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Not authorised|[error](#schemaerror)|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## Schemas
+
+<h3 id="tocS_address">address</h3>
+<!-- backwards compatibility -->
+<a id="schemaaddress"></a>
+<a id="schema_address"></a>
+<a id="tocSaddress"></a>
+<a id="tocsaddress"></a>
+
+```json
+{
+  "address_line_1": "string",
+  "address_line_2": "string",
+  "care_of": "string",
+  "country": "string",
+  "locality": "string",
+  "po_box": "string",
+  "postal_code": "string",
+  "premises": "string",
+  "region": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|address_line_1|string|true|none|The first line of the address.|
+|address_line_2|string|false|none|The second line of the address.|
+|care_of|string|false|none|Care of name.|
+|country|string|false|none|The country. For example, UK.|
+|locality|string|false|none|The locality. For example London.|
+|po_box|string|false|none|The post-officer box number.|
+|postal_code|string|true|none|The postal code. For example CF14 3UZ.|
+|premises|string|true|none|The property name or number.|
+|region|string|false|none|The region. For example Surrey.|
+
+<h3 id="tocS_individual">individual</h3>
+<!-- backwards compatibility -->
+<a id="schemaindividual"></a>
+<a id="schema_individual"></a>
+<a id="tocSindividual"></a>
+<a id="tocsindividual"></a>
+
+```json
+{
+  "etag": "string",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "kind": "individual-person-with-significant-control",
+  "country_of_residence": "string",
+  "date_of_birth": [
+    {
+      "day": 0,
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "name": "string",
+  "name_elements": [
+    {
+      "forename": "string",
+      "title": "string",
+      "other_forenames": "string",
+      "surname": "string"
+    }
+  ],
+  "links": [
+    {
+      "self": "string",
+      "statement": "string"
+    }
+  ],
+  "nationality": "string",
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "natures_of_control": [
+    "ownership-of-shares-25-to-50-percent"
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|notified_on|string(date)|true|none|The date that Companies House was notified about this person with significant control.|
+|ceased_on|string(date)|false|none|The date that Companies House was notified about the cessation of this person with significant control.|
+|kind|string|true|none|none|
+|country_of_residence|string|true|none|The country of residence of the person with significant control.|
+|date_of_birth|[[dateOfBirth](#schemadateofbirth)]|true|none|The date of birth of the person with significant control.|
+|name|string|true|none|Name of the person with significant control.|
+|name_elements|[[nameElements](#schemanameelements)]|true|none|A document encapsulating the seperate elements of a person with significant control's name.|
+|links|[[pscLinksType](#schemapsclinkstype)]|true|none|A set of URLs related to the resource, including self.|
+|nationality|string|true|none|The nationality of the person with significant control.|
+|address|[[address](#schemaaddress)]|true|none|The service address of the person with significant control. If given, this address will be shown on the public record instead of the residential address.|
+|natures_of_control|[string]|true|none|Indicates the nature of control the person with significant control holds.  For enumeration descriptions see `description` section in the enumeration mappings file.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|individual-person-with-significant-control|
+
+<h3 id="tocS_listSummary">listSummary</h3>
+<!-- backwards compatibility -->
+<a id="schemalistsummary"></a>
+<a id="schema_listSummary"></a>
+<a id="tocSlistsummary"></a>
+<a id="tocslistsummary"></a>
+
+```json
+{
+  "etag": "string",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "country_of_residence": "string",
+  "date_of_birth": [
+    {
+      "day": 0,
+      "month": 0,
+      "year": 0
+    }
+  ],
+  "name": "string",
+  "name_elements": [
+    {
+      "forename": "string",
+      "title": "string",
+      "other_forenames": "string",
+      "surname": "string"
+    }
+  ],
+  "links": [
+    {
+      "self": "string",
+      "statement": "string"
+    }
+  ],
+  "nationality": "string",
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "natures_of_control": [
+    "ownership-of-shares-25-to-50-percent"
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|notified_on|string(date)|true|none|The date that Companies House was notified about this person with significant control.|
+|ceased_on|string(date)|false|none|The date that Companies House was notified about the cessation of this person with significant control.|
+|country_of_residence|string|false|none|The country of residence of the person with significant control.|
+|date_of_birth|[[dateOfBirth](#schemadateofbirth)]|false|none|The date of birth of the person with significant control.|
+|name|string|true|none|Name of the person with significant control.|
+|name_elements|[[nameElements](#schemanameelements)]|false|none|A document encapsulating the seperate elements of a person with significant control's name.|
+|links|[[pscLinksType](#schemapsclinkstype)]|true|none|A set of URLs related to the resource, including self.|
+|nationality|string|false|none|The nationality of the person with significant control.|
+|address|[[address](#schemaaddress)]|true|none|The service address of the person with significant control. If given, this address will be shown on the public record instead of the residential address.|
+|natures_of_control|[string]|true|none|Indicates the nature of control the person with significant control holds.  For enumeration descriptions see `description` section in the enumeration mappings file.|
+
+<h3 id="tocS_superSecure">superSecure</h3>
+<!-- backwards compatibility -->
+<a id="schemasupersecure"></a>
+<a id="schema_superSecure"></a>
+<a id="tocSsupersecure"></a>
+<a id="tocssupersecure"></a>
+
+```json
+{
+  "etag": "string",
+  "kind": "super-secure-person-with-significant-control",
+  "description": "super-secure-persons-with-significant-control",
+  "ceased": true,
+  "links": [
+    {
+      "self": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|kind|string|true|none|none|
+|description|string|true|none|Description of the super secure legal statement|
+|ceased|boolean|false|none|Presence of that indicator means the super secure person status is ceased|
+|links|[[superSecureLinksType](#schemasupersecurelinkstype)]|true|none|A set of URLs related to the resource, including self.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|super-secure-person-with-significant-control|
+|description|super-secure-persons-with-significant-control|
+
+<h3 id="tocS_dateOfBirth">dateOfBirth</h3>
+<!-- backwards compatibility -->
+<a id="schemadateofbirth"></a>
+<a id="schema_dateOfBirth"></a>
+<a id="tocSdateofbirth"></a>
+<a id="tocsdateofbirth"></a>
+
+```json
+{
+  "day": 0,
+  "month": 0,
+  "year": 0
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|day|integer|false|none|The day of the date of birth.|
+|month|integer|true|none|The month of date of birth.|
+|year|integer|true|none|The year of date of birth.|
+
+<h3 id="tocS_corporateEntity">corporateEntity</h3>
+<!-- backwards compatibility -->
+<a id="schemacorporateentity"></a>
+<a id="schema_corporateEntity"></a>
+<a id="tocScorporateentity"></a>
+<a id="tocscorporateentity"></a>
+
+```json
+{
+  "etag": "string",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "kind": "corporate-entity-person-with-significant-control",
+  "name": "string",
+  "links": [
+    {
+      "self": "string",
+      "statement": "string"
+    }
+  ],
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "identification": [
+    {
+      "legal_authority": "string",
+      "legal_form": "string",
+      "place_registered": "string",
+      "registration_number": "string",
+      "country_registered": "string"
+    }
+  ],
+  "natures_of_control": [
+    "ownership-of-shares-25-to-50-percent"
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|notified_on|string(date)|true|none|The date that Companies House was notified about this person with significant control.|
+|ceased_on|string(date)|false|none|The date that Companies House was notified about the cessation of this person with significant control.|
+|kind|string|true|none|none|
+|name|string|true|none|Name of the person with significant control.|
+|links|[[pscLinksType](#schemapsclinkstype)]|true|none|A set of URLs related to the resource, including self.|
+|address|[[address](#schemaaddress)]|true|none|The address of the person with significant control.|
+|identification|[[corporateEntityIdent](#schemacorporateentityident)]|true|none|none|
+|natures_of_control|[string]|true|none|Indicates the nature of control the person with significant control holds.  For enumeration descriptions see `description` section in the enumeration mappings file.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|corporate-entity-person-with-significant-control|
+
+<h3 id="tocS_corporateEntityIdent">corporateEntityIdent</h3>
+<!-- backwards compatibility -->
+<a id="schemacorporateentityident"></a>
+<a id="schema_corporateEntityIdent"></a>
+<a id="tocScorporateentityident"></a>
+<a id="tocscorporateentityident"></a>
+
+```json
+{
+  "legal_authority": "string",
+  "legal_form": "string",
+  "place_registered": "string",
+  "registration_number": "string",
+  "country_registered": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|legal_authority|string|true|none|The legal authority supervising the corporate entity with significant control.|
+|legal_form|string|true|none|The legal form of the corporate entity with significant control as defined by its country of registration.|
+|place_registered|string|false|none|The place the corporate entity with significant control is registered.|
+|registration_number|string|false|none|The registration number of the corporate entity with significant control.|
+|country_registered|string|false|none|The country or state the corporate entity with significant control is registered in.|
+
+<h3 id="tocS_error">error</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror"></a>
+<a id="schema_error"></a>
+<a id="tocSerror"></a>
+<a id="tocserror"></a>
+
+```json
+{
+  "errors": [
+    {
+      "type": "ch:service",
+      "location_type": "json-path",
+      "location": "string",
+      "error": "string",
+      "error_values": [
+        {
+          "argument": {}
+        }
+      ]
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|errors|[[errorDetail](#schemaerrordetail)]|true|none|A list of errors found|
+
+<h3 id="tocS_list">list</h3>
+<!-- backwards compatibility -->
+<a id="schemalist"></a>
+<a id="schema_list"></a>
+<a id="tocSlist"></a>
+<a id="tocslist"></a>
+
+```json
+{
+  "etag": "string",
+  "items_per_page": 0,
+  "kind": "persons-with-significant-control#list",
+  "items": [
+    {
+      "etag": "string",
+      "notified_on": "2020-04-08",
+      "ceased_on": "2020-04-08",
+      "country_of_residence": "string",
+      "date_of_birth": [
+        {
+          "day": 0,
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "name": "string",
+      "name_elements": [
+        {
+          "forename": "string",
+          "title": "string",
+          "other_forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "links": [
+        {
+          "self": "string",
+          "statement": "string"
+        }
+      ],
+      "nationality": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "natures_of_control": [
+        "ownership-of-shares-25-to-50-percent"
+      ]
+    }
+  ],
+  "start_index": 0,
+  "total_results": 0,
+  "active_count": 0,
+  "ceased_count": 0,
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control_statements_list": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|items_per_page|integer|true|none|The number of persons with significant control to return per page.|
+|kind|string|true|none|none|
+|items|[[listSummary](#schemalistsummary)]|true|none|The list of persons with significant control.|
+|start_index|integer|true|none|The offset into the entire result set that this page starts.|
+|total_results|integer|true|none|The total number of persons with significant control in this result set.|
+|active_count|integer|true|none|The number of active persons with significant control in this result set.|
+|ceased_count|integer|true|none|The number of ceased persons with significant control in this result set.|
+|links|[[pscListLinksType](#schemapsclistlinkstype)]|true|none|A set of URLs related to the resource, including self.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|persons-with-significant-control#list|
+
+<h3 id="tocS_corporateEntityList">corporateEntityList</h3>
+<!-- backwards compatibility -->
+<a id="schemacorporateentitylist"></a>
+<a id="schema_corporateEntityList"></a>
+<a id="tocScorporateentitylist"></a>
+<a id="tocscorporateentitylist"></a>
+
+```json
+{
+  "etag": "string",
+  "items_per_page": 0,
+  "kind": "persons-with-significant-control#list-corporate-entity",
+  "items": [
+    {
+      "etag": "string",
+      "notified_on": "2020-04-08",
+      "ceased_on": "2020-04-08",
+      "country_of_residence": "string",
+      "date_of_birth": [
+        {
+          "day": 0,
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "name": "string",
+      "name_elements": [
+        {
+          "forename": "string",
+          "title": "string",
+          "other_forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "links": [
+        {
+          "self": "string",
+          "statement": "string"
+        }
+      ],
+      "nationality": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "natures_of_control": [
+        "ownership-of-shares-25-to-50-percent"
+      ]
+    }
+  ],
+  "start_index": 0,
+  "total_results": 0,
+  "active_count": 0,
+  "ceased_count": 0,
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control_statements_list": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|items_per_page|integer|true|none|The number of corporate entity persons with significant control to return per page.|
+|kind|string|true|none|none|
+|items|[[listSummary](#schemalistsummary)]|true|none|The list of corporate entity persons with significant control.|
+|start_index|integer|true|none|The offset into the entire result set that this page starts.|
+|total_results|integer|true|none|The total number of corporate entity persons with significant control in this result set.|
+|active_count|integer|true|none|The number of active persons with significant control in this result set.|
+|ceased_count|integer|true|none|The number of ceased persons with significant control in this result set.|
+|links|[[pscListLinksType](#schemapsclistlinkstype)]|true|none|A set of URLs related to the resource, including self.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|persons-with-significant-control#list-corporate-entity|
+
+<h3 id="tocS_pscListLinksType">pscListLinksType</h3>
+<!-- backwards compatibility -->
+<a id="schemapsclistlinkstype"></a>
+<a id="schema_pscListLinksType"></a>
+<a id="tocSpsclistlinkstype"></a>
+<a id="tocspsclistlinkstype"></a>
+
+```json
+{
+  "self": "string",
+  "persons_with_significant_control_statements_list": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of the resource.|
+|persons_with_significant_control_statements_list|string|false|none|The URL of the persons with significant control statements list resource.|
+
+<h3 id="tocS_statementLinksType">statementLinksType</h3>
+<!-- backwards compatibility -->
+<a id="schemastatementlinkstype"></a>
+<a id="schema_statementLinksType"></a>
+<a id="tocSstatementlinkstype"></a>
+<a id="tocsstatementlinkstype"></a>
+
+```json
+{
+  "self": "string",
+  "person_with_significant_control": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of the resource.|
+|person_with_significant_control|string|false|none|The URL of the person with significant control linked to this statement.|
+
+<h3 id="tocS_error_values">error_values</h3>
+<!-- backwards compatibility -->
+<a id="schemaerror_values"></a>
+<a id="schema_error_values"></a>
+<a id="tocSerror_values"></a>
+<a id="tocserror_values"></a>
+
+```json
+{
+  "argument": {}
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|argument|object|false|none|The element name and value pair required to complete the error description, will repeat as necessary.|
+
+<h3 id="tocS_statementListLinksType">statementListLinksType</h3>
+<!-- backwards compatibility -->
+<a id="schemastatementlistlinkstype"></a>
+<a id="schema_statementListLinksType"></a>
+<a id="tocSstatementlistlinkstype"></a>
+<a id="tocsstatementlistlinkstype"></a>
+
+```json
+{
+  "self": "string",
+  "persons_with_significant_control_list": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of the resource.|
+|persons_with_significant_control_list|string|false|none|The URL of the persons with significant control list resource.|
+
+<h3 id="tocS_statementList">statementList</h3>
+<!-- backwards compatibility -->
+<a id="schemastatementlist"></a>
+<a id="schema_statementList"></a>
+<a id="tocSstatementlist"></a>
+<a id="tocsstatementlist"></a>
+
+```json
+{
+  "etag": "string",
+  "items_per_page": 0,
+  "kind": "persons-with-significant-control#statements-list",
+  "items": [
+    {
+      "etag": "string",
+      "kind": "person-with-significant-control-statement",
+      "notified_on": "2020-04-08",
+      "ceased_on": "2020-04-08",
+      "restrictions_notice_withdrawal_reason": "restrictions-notice-withdrawn-by-court-order",
+      "statement": "no-individual-or-entity-with-signficant-control",
+      "linked_psc_name": "string",
+      "links": [
+        {
+          "self": "string",
+          "person_with_significant_control": "string"
+        }
+      ]
+    }
+  ],
+  "start_index": 0,
+  "total_results": 0,
+  "active_count": 0,
+  "ceased_count": 0,
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control_list": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|items_per_page|integer|true|none|The number of persons with significant control statements to return per page.|
+|kind|string|true|none|none|
+|items|[[statement](#schemastatement)]|true|none|The list of persons with significant control statements.|
+|start_index|integer|true|none|The offset into the entire result set that this page starts.|
+|total_results|integer|true|none|The total number of persons with significant control statements in this result set.|
+|active_count|integer|true|none|The number of active persons with significant control statements in this result set.|
+|ceased_count|integer|true|none|The number of ceased persons with significant control statements in this result set.|
+|links|[[statementListLinksType](#schemastatementlistlinkstype)]|true|none|A set of URLs related to the resource, including self.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|persons-with-significant-control#statements-list|
+
+<h3 id="tocS_legalPerson">legalPerson</h3>
+<!-- backwards compatibility -->
+<a id="schemalegalperson"></a>
+<a id="schema_legalPerson"></a>
+<a id="tocSlegalperson"></a>
+<a id="tocslegalperson"></a>
+
+```json
+{
+  "etag": "string",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "kind": "legal-person-with-significant-control",
+  "name": "string",
+  "links": [
+    {
+      "self": "string",
+      "statement": "string"
+    }
+  ],
+  "address": [
+    {
+      "address_line_1": "string",
+      "address_line_2": "string",
+      "care_of": "string",
+      "country": "string",
+      "locality": "string",
+      "po_box": "string",
+      "postal_code": "string",
+      "premises": "string",
+      "region": "string"
+    }
+  ],
+  "identification": [
+    {
+      "legal_authority": "string",
+      "legal_form": "string"
+    }
+  ],
+  "natures_of_control": [
+    "ownership-of-shares-25-to-50-percent"
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|notified_on|string(date)|true|none|The date that Companies House was notified about this person with significant control.|
+|ceased_on|string(date)|false|none|The date that Companies House was notified about the cessation of this person with significant control.|
+|kind|string|true|none|none|
+|name|string|true|none|Name of the person with significant control.|
+|links|[[pscLinksType](#schemapsclinkstype)]|true|none|A set of URLs related to the resource, including self.|
+|address|[[address](#schemaaddress)]|true|none|The address of the person with significant control.|
+|identification|[[legalPersonIdent](#schemalegalpersonident)]|true|none|none|
+|natures_of_control|[string]|true|none|Indicates the nature of control the person with significant control holds.  For enumeration descriptions see `description` section in the enumeration mappings file.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|legal-person-with-significant-control|
+
+<h3 id="tocS_statement">statement</h3>
+<!-- backwards compatibility -->
+<a id="schemastatement"></a>
+<a id="schema_statement"></a>
+<a id="tocSstatement"></a>
+<a id="tocsstatement"></a>
+
+```json
+{
+  "etag": "string",
+  "kind": "person-with-significant-control-statement",
+  "notified_on": "2020-04-08",
+  "ceased_on": "2020-04-08",
+  "restrictions_notice_withdrawal_reason": "restrictions-notice-withdrawn-by-court-order",
+  "statement": "no-individual-or-entity-with-signficant-control",
+  "linked_psc_name": "string",
+  "links": [
+    {
+      "self": "string",
+      "person_with_significant_control": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|kind|string|true|none|none|
+|notified_on|string(date)|true|none|The date that the person with significant control statement was processed by Companies House.|
+|ceased_on|string(date)|false|none|The date that Companies House was notified about the cessation of this person with significant control.|
+|restrictions_notice_withdrawal_reason|string|false|none|The reason for the company withdrawing a `restrictions-notice-issued-to-psc` statement|
+|statement|string|true|none|Indicates the type of statement filed.  For enumeration descriptions see `statement_description` section in the enumeration mappings file.|
+|linked_psc_name|string|false|none|The name of the psc linked to this statement.|
+|links|[[statementLinksType](#schemastatementlinkstype)]|true|none|A set of URLs related to the resource, including self.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|person-with-significant-control-statement|
+|restrictions_notice_withdrawal_reason|restrictions-notice-withdrawn-by-court-order|
+|restrictions_notice_withdrawal_reason|restrictions-notice-withdrawn-by-company|
+|statement|no-individual-or-entity-with-signficant-control|
+|statement|steps-to-find-psc-not-yet-completed|
+|statement|psc-exists-but-not-identified|
+|statement|psc-details-not-confirmed|
+|statement|psc-contacted-but-no-response|
+|statement|restrictions-notice-issued-to-psc|
+|statement|psc-has-failed-to-confirm-changed-details|
+
+<h3 id="tocS_errorDetail">errorDetail</h3>
+<!-- backwards compatibility -->
+<a id="schemaerrordetail"></a>
+<a id="schema_errorDetail"></a>
+<a id="tocSerrordetail"></a>
+<a id="tocserrordetail"></a>
+
+```json
+{
+  "type": "ch:service",
+  "location_type": "json-path",
+  "location": "string",
+  "error": "string",
+  "error_values": [
+    {
+      "argument": {}
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|type|string|true|none|Type of error.|
+|location_type|string|false|none|Describes the type of location returned so that it may be parsed appropriately.|
+|location|string|false|none|The location in the submitted request in which the error relates. This parameter is only provided when errors[].type is set to "ch:validation".|
+|error|string|true|none|The error being returned. See github for valid [https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml](https://github.com/companieshouse/api-enumerations/blob/develop/errors.yml)error enumeration types.|
+|error_values|[[error_values](#schemaerror_values)]|false|none|A collection of argument name and value pairs which, when substituted into the error string, provide the full description of the error. As many name/value pairs as necessary to complete the error description are returned. See example above.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|type|ch:service|
+|type|ch:validation|
+|location_type|json-path|
+|location_type|query-parameter|
+
+<h3 id="tocS_legalPersonList">legalPersonList</h3>
+<!-- backwards compatibility -->
+<a id="schemalegalpersonlist"></a>
+<a id="schema_legalPersonList"></a>
+<a id="tocSlegalpersonlist"></a>
+<a id="tocslegalpersonlist"></a>
+
+```json
+{
+  "etag": "string",
+  "items_per_page": 0,
+  "kind": "persons-with-significant-control#list-legal-person",
+  "items": [
+    {
+      "etag": "string",
+      "notified_on": "2020-04-08",
+      "ceased_on": "2020-04-08",
+      "country_of_residence": "string",
+      "date_of_birth": [
+        {
+          "day": 0,
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "name": "string",
+      "name_elements": [
+        {
+          "forename": "string",
+          "title": "string",
+          "other_forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "links": [
+        {
+          "self": "string",
+          "statement": "string"
+        }
+      ],
+      "nationality": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "natures_of_control": [
+        "ownership-of-shares-25-to-50-percent"
+      ]
+    }
+  ],
+  "start_index": 0,
+  "total_results": 0,
+  "active_count": 0,
+  "ceased_count": 0,
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control_statements_list": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|items_per_page|integer|true|none|The number of legal persons with significant control to return per page.|
+|kind|string|true|none|none|
+|items|[[listSummary](#schemalistsummary)]|true|none|The list of legal persons with significant control.|
+|start_index|integer|true|none|The offset into the entire result set that this page starts.|
+|total_results|integer|true|none|The total number of legal persons with significant control in this result set.|
+|active_count|integer|true|none|The number of active persons with significant control in this result set.|
+|ceased_count|integer|true|none|The number of ceased persons with significant control in this result set.|
+|links|[[pscListLinksType](#schemapsclistlinkstype)]|true|none|A set of URLs related to the resource, including self.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|persons-with-significant-control#list-legal-person|
+
+<h3 id="tocS_individualList">individualList</h3>
+<!-- backwards compatibility -->
+<a id="schemaindividuallist"></a>
+<a id="schema_individualList"></a>
+<a id="tocSindividuallist"></a>
+<a id="tocsindividuallist"></a>
+
+```json
+{
+  "etag": "string",
+  "items_per_page": 0,
+  "kind": "persons-with-significant-control#list-individual",
+  "items": [
+    {
+      "etag": "string",
+      "notified_on": "2020-04-08",
+      "ceased_on": "2020-04-08",
+      "country_of_residence": "string",
+      "date_of_birth": [
+        {
+          "day": 0,
+          "month": 0,
+          "year": 0
+        }
+      ],
+      "name": "string",
+      "name_elements": [
+        {
+          "forename": "string",
+          "title": "string",
+          "other_forenames": "string",
+          "surname": "string"
+        }
+      ],
+      "links": [
+        {
+          "self": "string",
+          "statement": "string"
+        }
+      ],
+      "nationality": "string",
+      "address": [
+        {
+          "address_line_1": "string",
+          "address_line_2": "string",
+          "care_of": "string",
+          "country": "string",
+          "locality": "string",
+          "po_box": "string",
+          "postal_code": "string",
+          "premises": "string",
+          "region": "string"
+        }
+      ],
+      "natures_of_control": [
+        "ownership-of-shares-25-to-50-percent"
+      ]
+    }
+  ],
+  "start_index": 0,
+  "total_results": 0,
+  "active_count": 0,
+  "ceased_count": 0,
+  "links": [
+    {
+      "self": "string",
+      "persons_with_significant_control_statements_list": "string"
+    }
+  ]
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|etag|string|true|none|The ETag of the resource.|
+|items_per_page|integer|true|none|The number of individual persons with significant control to return per page.|
+|kind|string|true|none|none|
+|items|[[listSummary](#schemalistsummary)]|true|none|The list of individual persons with significant control.|
+|start_index|integer|true|none|The offset into the entire result set that this page starts.|
+|total_results|integer|true|none|The total number of individual persons with significant control in this result set.|
+|active_count|integer|true|none|The number of active persons with significant control in this result set.|
+|ceased_count|integer|true|none|The number of ceased persons with significant control in this result set.|
+|links|[[pscListLinksType](#schemapsclistlinkstype)]|true|none|A set of URLs related to the resource, including self.|
+
+##### Enumerated Values
+
+|Property|Value|
+|---|---|
+|kind|persons-with-significant-control#list-individual|
+
+<h3 id="tocS_pscLinksType">pscLinksType</h3>
+<!-- backwards compatibility -->
+<a id="schemapsclinkstype"></a>
+<a id="schema_pscLinksType"></a>
+<a id="tocSpsclinkstype"></a>
+<a id="tocspsclinkstype"></a>
+
+```json
+{
+  "self": "string",
+  "statement": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of the resource.|
+|statement|string|false|none|The URL of the statement linked to this person with significant control.|
+
+<h3 id="tocS_superSecureLinksType">superSecureLinksType</h3>
+<!-- backwards compatibility -->
+<a id="schemasupersecurelinkstype"></a>
+<a id="schema_superSecureLinksType"></a>
+<a id="tocSsupersecurelinkstype"></a>
+<a id="tocssupersecurelinkstype"></a>
+
+```json
+{
+  "self": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|self|string|true|none|The URL of the resource.|
+
+<h3 id="tocS_nameElements">nameElements</h3>
+<!-- backwards compatibility -->
+<a id="schemanameelements"></a>
+<a id="schema_nameElements"></a>
+<a id="tocSnameelements"></a>
+<a id="tocsnameelements"></a>
+
+```json
+{
+  "forename": "string",
+  "title": "string",
+  "other_forenames": "string",
+  "surname": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|forename|string|false|none|The forename of the person with significant control.|
+|title|string|false|none|Title of the person with significant control.|
+|other_forenames|string|false|none|Other forenames of the person with significant control.|
+|surname|string|true|none|The surname of the person with significant control.|
+
+<h3 id="tocS_legalPersonIdent">legalPersonIdent</h3>
+<!-- backwards compatibility -->
+<a id="schemalegalpersonident"></a>
+<a id="schema_legalPersonIdent"></a>
+<a id="tocSlegalpersonident"></a>
+<a id="tocslegalpersonident"></a>
+
+```json
+{
+  "legal_authority": "string",
+  "legal_form": "string"
+}
+
+```
+
+#### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|legal_authority|string|true|none|The legal authority supervising the legal person with significant control.|
+|legal_form|string|true|none|The legal form of the legal person with significant control as defined by its country of registration.|
+


### PR DESCRIPTION
Added Markdown files for all public facing specification that have been converted to OpenAPI3;

- charges.html.md;
- companyAddress.html.md;
- companyOfficerList.html.md;
- companyProfile.html.md;
- companyRegisters.html.md;
- companyUKEstablishments.html.md;
- disqualifications.html.md;
- /exemptions.html.md;
- filingHistory.html.md;
- index.html.md (this is the search.json schema but the tooling required one file as a homepage and chose this to be the homepage of index.html.md);
- insolvency.html.md;
- officerAppointmentList.html.md;
- psc.html.md;